### PR TITLE
ci: add SemVer release workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+-
+
+## User-visible changes
+
+-
+
+## Changelog
+
+- [ ] Updated `CHANGELOG.md`
+- [ ] Not needed: internal-only change
+
+Changelog entries must be written in English because GitHub Release notes are generated from `CHANGELOG.md`.
+
+## Verification
+
+-

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,136 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate changelog entry
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+          changed_files="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          printf 'Changed files:\n%s\n' "${changed_files}"
+
+          changelog_required=false
+          while IFS= read -r path; do
+            [ -n "${path}" ] || continue
+            case "${path}" in
+              README.md|README_en.md|skills/**|scripts/**)
+                changelog_required=true
+                ;;
+              CHANGELOG.md|.github/**|*.md|docs/**|assets/**)
+                ;;
+              *)
+                changelog_required=true
+                ;;
+            esac
+          done <<< "${changed_files}"
+
+          if [ "${changelog_required}" != "true" ]; then
+            echo "Changelog not required for this PR."
+            exit 0
+          fi
+
+          if ! printf '%s\n' "${changed_files}" | grep -qx 'CHANGELOG.md'; then
+            echo "Missing changelog update. Add a user-facing entry to CHANGELOG.md under ## Unreleased."
+            exit 1
+          fi
+
+          added_lines="$(
+            git diff --unified=0 "origin/${BASE_REF}...HEAD" -- CHANGELOG.md |
+              awk '/^\+\+\+/ { next } /^\+/ { print substr($0, 2) }'
+          )"
+
+          if [ -z "${added_lines}" ]; then
+            echo "CHANGELOG.md changed, but no added lines were found."
+            exit 1
+          fi
+
+          pr_pattern="(#${PR_NUMBER})"
+          if ! printf '%s\n' "${added_lines}" | grep -Fq "${pr_pattern}"; then
+            echo "CHANGELOG.md entry must reference this PR as ${pr_pattern}."
+            exit 1
+          fi
+
+          node <<'NODE'
+          const { execSync } = require("node:child_process");
+          const fs = require("node:fs");
+
+          const base = process.env.BASE_REF;
+          const pr = process.env.PR_NUMBER;
+          const diff = execSync(`git diff --unified=0 origin/${base}...HEAD -- CHANGELOG.md`, {
+            encoding: "utf8",
+          });
+          const changelog = fs.readFileSync("CHANGELOG.md", "utf8").split(/\r?\n/);
+          const prToken = `(#${pr})`;
+          let currentLine = 0;
+          const addedPrLines = [];
+
+          for (const line of diff.split(/\r?\n/)) {
+            if (line.startsWith("@@ ")) {
+              const match = line.match(/\+(\d+)/);
+              currentLine = match ? Number(match[1]) : 0;
+              continue;
+            }
+            if (line.startsWith("+++") || line.startsWith("---")) {
+              continue;
+            }
+            if (line.startsWith("+")) {
+              const text = line.slice(1);
+              if (text.includes(prToken)) {
+                addedPrLines.push({ line: currentLine, text });
+              }
+              if (currentLine > 0) currentLine += 1;
+              continue;
+            }
+            if (line.startsWith("-")) {
+              continue;
+            }
+            if (currentLine > 0) currentLine += 1;
+          }
+
+          if (addedPrLines.length === 0) {
+            console.error(`No added CHANGELOG.md line references ${prToken}.`);
+            process.exit(1);
+          }
+
+          for (const entry of addedPrLines) {
+            let release = "";
+            let subsection = "";
+            for (let i = entry.line - 1; i >= 0; i -= 1) {
+              const line = changelog[i] ?? "";
+              if (!subsection && line.startsWith("### ")) {
+                subsection = line;
+              }
+              if (line.startsWith("## ")) {
+                release = line;
+                break;
+              }
+            }
+            if (release !== "## Unreleased") {
+              console.error(`Changelog PR entry must be under ## Unreleased: line ${entry.line}`);
+              process.exit(1);
+            }
+            if (!subsection) {
+              console.error(`Changelog PR entry must be inside a ### subsection: line ${entry.line}`);
+              process.exit(1);
+            }
+          }
+          NODE

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate semantic PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${PR_TITLE}" =~ ^(feat|fix|docs|chore|refactor|test|ci|perf|build|revert)(\([a-zA-Z0-9._-]+\))?!?:\ .+ ]]; then
+            echo "PR title must follow Conventional Commit style, for example:"
+            echo "  feat: add release workflow"
+            echo "  fix: handle missing API key"
+            echo "  docs: clarify install steps"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate SemVer tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${TAG_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag must be SemVer with a leading v, for example v0.1.0 or v0.2.0-beta.1."
+            exit 1
+          fi
+
+      - name: Extract release notes
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          version="${TAG_NAME#v}"
+          notes_file="${RUNNER_TEMP}/release-notes.md"
+
+          awk -v version="${version}" '
+            $0 == "## " version {
+              found = 1
+              next
+            }
+            found && /^## / {
+              exit
+            }
+            found {
+              print
+            }
+          ' CHANGELOG.md > "${notes_file}"
+
+          if [ ! -s "${notes_file}" ]; then
+            echo "No CHANGELOG.md section found for ${version}."
+            echo "Add a section like: ## ${version}"
+            exit 1
+          fi
+
+          if ! grep -Eq '^- .+\(#[0-9]+\)' "${notes_file}"; then
+            echo "Release notes for ${version} must include at least one changelog entry with a PR reference like (#12)."
+            exit 1
+          fi
+
+          {
+            echo "## Release notes"
+            echo
+            cat "${notes_file}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          gh release create "${TAG_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${TAG_NAME}" \
+            --notes-file "${RUNNER_TEMP}/release-notes.md" \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Release notes are generated from this file. Keep changelog entries in English.
+
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+## 0.1.0
+
+### Added
+
+- Add the initial Codex PPT skill and style assets. (#1)
+- Add installation and usage documentation. (#2)


### PR DESCRIPTION
## Summary

- Add a lightweight SemVer release process starting at v0.1.0.
- Add CHANGELOG.md as the source for GitHub Release notes.
- Add PR title and changelog checks so future PRs leave release-note entries.

## User-visible changes

- GitHub Releases will use English changelog entries with PR references.
- Pushing a SemVer tag like v0.1.0 will create a release from the matching CHANGELOG.md section.

## Changelog

- [x] Updated CHANGELOG.md
- [ ] Not needed: internal-only change

## Verification

- Parsed all workflow YAML files with Ruby YAML.
- Ran bash -n against every workflow run script.
- Simulated extracting release notes for v0.1.0 from CHANGELOG.md.