### PR TITLE
docs: add agent contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 - [ ] Not needed: internal-only change
 
 Changelog entries must be written in English because GitHub Release notes are generated from `CHANGELOG.md`.
+If a changelog entry is required, add the PR reference after opening the PR, for example `(#12)`.
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@
   - `### Fixes`
   - `### Documentation`
 - Changelog entries must be written in English.
-- Changelog entries should include the PR reference after the PR is opened, for example `(#12)`.
+- Changelog entries must include the PR reference after the PR is opened, for example `(#12)`.
+- If the PR number is not known when the first commit is made, open the PR first and then push a follow-up commit that adds the `(#PR_NUMBER)` reference.
 
 ## Release Process
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Contribution Flow
+
+- All non-trivial changes should go through a pull request.
+- PR titles must follow Conventional Commit style, for example:
+  - `feat: add new slide style`
+  - `fix: handle missing image API key`
+  - `docs: clarify installation steps`
+- Commit messages, PR titles, changelog entries, and release notes must be written in English.
+
+## Changelog
+
+- User-visible changes must update `CHANGELOG.md`.
+- Add unreleased entries under `## Unreleased`.
+- Use one of these sections:
+  - `### Features`
+  - `### Improvements`
+  - `### Fixes`
+  - `### Documentation`
+- Changelog entries must be written in English.
+- Changelog entries should include the PR reference after the PR is opened, for example `(#12)`.
+
+## Release Process
+
+- Versions use SemVer.
+- Git tags must use a leading `v`, for example `v0.1.0`.
+- GitHub Releases are generated from the matching `CHANGELOG.md` version section.
+- Do not write GitHub Release notes manually unless updating an existing release body to match `CHANGELOG.md`.
+
+## Verification
+
+- Before opening a PR, verify changed GitHub workflow YAML parses when practical.
+- For workflow shell snippets, run a syntax check such as `bash -n` when practical.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Documentation
 
+- Add agent contribution guidelines for PR, changelog, and release workflows.
+
 ## 0.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Documentation
 
-- Add agent contribution guidelines for PR, changelog, and release workflows.
+- Add agent contribution guidelines for PR, changelog, and release workflows. (#5)
 
 ## 0.1.0
 


### PR DESCRIPTION
## Summary

- Add AGENTS.md with repository-specific guidance for agent contributors.
- Document PR title, changelog, SemVer tag, and release-note expectations.

## User-visible changes

- Agent contributors get a clear contribution workflow for future changes.

## Changelog

- [x] Updated CHANGELOG.md
- [ ] Not needed: internal-only change

## Verification

- Reviewed AGENTS.md content to ensure it does not include a reply-language requirement.
- Confirmed changelog entry is under Documentation in Unreleased.