### PR TITLE
ci: give required checks unique job names

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  changelog-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  pr-title:
     runs-on: ubuntu-latest
     steps:
       - name: Validate semantic PR title


### PR DESCRIPTION
## Summary
- Rename the Changelog Check job from `validate` to `changelog-check`
- Rename the PR Title job from `validate` to `pr-title`
- Make required status checks unambiguous for branch protection

## Verification
- `ruby -e 'require "yaml"; ARGV.each{|f| YAML.load_file(f); puts "ok #{f}"}' .github/workflows/*.yml`