### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.2.0
+
 ### Features
 
 - Add ClawHub publishing workflow and skill metadata. (#8)


### PR DESCRIPTION
Prepare CHANGELOG.md for the 0.2.0 release so tag-based release workflows can extract the matching release notes.