### PR TITLE
docs: clarify Codex built-in image fallback selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Fixes
 
+- Clarify that Codex built-in image generation remains the preferred `gpt-image-2` path when available, avoiding unnecessary API key prompts. (#11)
 - Omit empty changelog subsections from generated release notes. (#10)
 
 ## 0.2.0

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ ClawHub 页面：[clawhub.ai/ningzimu/codex-ppt](https://clawhub.ai/ningzimu/cod
 - 在 Codex 中使用第三方 API 或兼容中转站接入时，通常无法使用内置的图片生成工具。
 - 在 Claude Code、OpenClaw、Hermes Agent 等环境中使用该 skill。
 
-如果你是通过 GPT 会员订阅使用 Codex，并且 Codex 内置图片生成工具可用，则不需要配置 `gpt-image-2` 生图模型；这种情况下 Codex 已经内置了该图片生成能力。
+如果你是通过 GPT 会员订阅使用 Codex，并且 Codex 内置图片生成工具可用，则不需要配置 `gpt-image-2` 生图模型；这种情况下 Codex 已经内置了该图片生成能力。即使你在提示词里明确说“使用 `gpt-image-2`”，也应优先理解为使用 Codex 内置图片生成工具，而不是切换到本地 API/CLI fallback。
 
-需要 API/CLI fallback 时，agent 会在首次使用前检查 `~/.codex-ppt-skill/.env`。如果缺少 API key，agent 会引导你配置一次；`base URL` 只有使用第三方中转站时才需要配置，模型名缺省为 `gpt-image-2`，只有中转站要求自定义模型名时才需要修改。配置完成后 Codex、Claude Code、OpenClaw、Hermes Agent 会复用同一套配置。
+只有在已经明确选择 API/CLI fallback 时，agent 才应该检查 `~/.codex-ppt-skill/.env` 并在缺少配置时报 `OPENAI_API_KEY`。不要在 Codex 内置图片生成工具可用时，因为用户提到 `gpt-image-2` 就要求配置 API key。`base URL` 只有使用第三方中转站时才需要配置，模型名缺省为 `gpt-image-2`，只有中转站要求自定义模型名时才需要修改。配置完成后 Codex、Claude Code、OpenClaw、Hermes Agent 会复用同一套配置。
 
 手动排查时也可以直接运行配置命令：
 

--- a/README_en.md
+++ b/README_en.md
@@ -150,9 +150,9 @@ You only need to configure an image model when API/CLI fallback image generation
 - Using a third-party API or OpenAI-compatible proxy in Codex, where the built-in image generation tool is usually unavailable.
 - Using this skill from Claude Code, OpenClaw, Hermes Agent, or similar agents.
 
-If you use Codex through a GPT subscription and Codex's built-in image generation tool is available, you do not need to configure the `gpt-image-2` image model; in that setup, Codex already provides the image generation capability.
+If you use Codex through a GPT subscription and Codex's built-in image generation tool is available, you do not need to configure the `gpt-image-2` image model; in that setup, Codex already provides the image generation capability. Even when the user explicitly says “use `gpt-image-2`”, treat that as a request to use Codex's built-in image tool first, not as a reason to switch to the local API/CLI fallback.
 
-When API/CLI fallback is needed, the agent checks `~/.codex-ppt-skill/.env` before first use. If the API key is missing, the agent should guide you through one-time configuration. `base URL` is only needed when using a third-party proxy, and the model defaults to `gpt-image-2`; change the model only when your proxy requires a custom model name. After that, Codex, Claude Code, OpenClaw, and Hermes Agent reuse the same config.
+Only after API/CLI fallback has been intentionally selected should the agent check `~/.codex-ppt-skill/.env` and report a missing `OPENAI_API_KEY`. Do not ask for an API key in Codex just because the user mentioned `gpt-image-2` while the built-in image tool is available. `base URL` is only needed when using a third-party proxy, and the model defaults to `gpt-image-2`; change the model only when your proxy requires a custom model name. After that, Codex, Claude Code, OpenClaw, and Hermes Agent reuse the same config.
 
 For manual troubleshooting, you can also run the config command directly:
 

--- a/skills/codex-ppt/SKILL.md
+++ b/skills/codex-ppt/SKILL.md
@@ -55,11 +55,12 @@ This skill supports two image backends:
 
 Backend selection rules:
 
-- Prefer the built-in image tool when available. In Codex, this usually means the built-in `image_gen` tool. In OpenClaw, this may be `image_generate`. Resolution, quality, aspect ratio, or slide-edit requests alone do not require CLI/API fallback.
+- Prefer the built-in image tool when available. In Codex, this usually means the built-in `image_gen` tool. In OpenClaw, this may be `image_generate`. Resolution, quality, aspect ratio, slide-edit requests, or the user saying “use `gpt-image-2`” do not require CLI/API fallback.
+- In Codex, treat the built-in image tool as the preferred `gpt-image-2` path when it is available. If the user has a GPT subscription / Codex environment and asks for `gpt-image-2`, do not switch to `scripts/image_gen.py` only to satisfy the model name.
 - Use CLI/API fallback only when the built-in tool is unavailable, the user explicitly asks for API/CLI or a third-party OpenAI-compatible proxy, or the requested capability is unavailable in the built-in tool.
 - Before generating the first image, tell the user which backend you plan to use, why, and ask for confirmation. Do not treat being in a specific agent environment as proof that the built-in image tool is available.
 - CLI/API fallback loads `~/.codex-ppt-skill/.env` automatically. Run the CLI normally; do not manually parse `.env` or ask for configuration before an error.
-- Ask for configuration only after the CLI reports missing `OPENAI_API_KEY`, after authentication/base URL/model errors, or when the user explicitly wants to change API settings. Configure provided values with `scripts/codex_ppt_runtime.py config --api-key`.
+- Ask for `OPENAI_API_KEY` configuration only after you have intentionally selected CLI/API fallback and that fallback reports missing config, after authentication/base URL/model errors, or when the user explicitly wants to change API settings. Do not mention missing `OPENAI_API_KEY` while the Codex built-in image tool is available. Configure provided values with `scripts/codex_ppt_runtime.py config --api-key`.
 - For detailed fallback setup after an error, read `docs/image-model-configuration.md`.
 
 CLI/API fallback commands use the shared runtime environment. Let `{skill_root}` mean the directory containing this `SKILL.md`.


### PR DESCRIPTION
## Summary
- Clarify that Codex built-in image generation is the preferred gpt-image-2 path when available
- Prevent agents from switching to local API/CLI fallback just because the user says gpt-image-2
- Clarify that OPENAI_API_KEY should only be requested after CLI/API fallback is intentionally selected

## Verification
- `ruby -e 'require "yaml"; ARGV.each{|f| YAML.load_file(f); puts "ok #{f}"}' .github/workflows/*.yml`
- `python3 -m py_compile skills/codex-ppt/scripts/*.py`