### PR TITLE
fix: mark fallback image config optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Fixes
 
+- Mark local image API fallback config as optional so built-in image tool users do not see unnecessary missing-config warnings. (#12)
 - Clarify that Codex built-in image generation remains the preferred `gpt-image-2` path when available, avoiding unnecessary API key prompts. (#11)
 - Omit empty changelog subsections from generated release notes. (#10)
 

--- a/skills/codex-ppt/SKILL.md
+++ b/skills/codex-ppt/SKILL.md
@@ -7,8 +7,6 @@ metadata:
     requires:
       bins:
         - python3
-      config:
-        - ~/.codex-ppt-skill/.env
     primaryEnv: OPENAI_API_KEY
     envVars:
       - name: OPENAI_API_KEY


### PR DESCRIPTION
## Summary
- Remove the fallback runtime .env file from hard OpenClaw skill requirements
- Keep API key/base URL/model metadata as optional fallback configuration
- Avoid making built-in image tool users think OPENAI_API_KEY is required

## Verification
- `ruby -e 'require "yaml"; ARGV.each{|f| YAML.load_file(f); puts "ok #{f}"}' .github/workflows/*.yml`
- `python3 -m py_compile skills/codex-ppt/scripts/*.py`