### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.2.1
+
 ### Documentation
 
 - Fix README badge labels and GitHub star/fork badge style. (#16)


### PR DESCRIPTION
## Summary
- Move current unreleased changelog entries into `0.2.1`
- Prepare release notes for the `v0.2.1` tag

## Verification
- `git diff --check CHANGELOG.md`
