### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.3.0
+
 ### Documentation
 
 - Add an `Attention Is All You Need` example deck with preserved paper figures. (#18)


### PR DESCRIPTION
## Summary
- move the current unreleased changelog entries into the 0.3.0 release section

## Verification
- changelog-only release preparation
