### PR TITLE
fix: package skill-only release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,27 @@ jobs:
             cat "${notes_file}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Package skill zip
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          asset_dir="${RUNNER_TEMP}/release-assets"
+          asset_name="codex-ppt-skill-${TAG_NAME}.zip"
+          mkdir -p "${asset_dir}"
+
+          (
+            cd skills
+            zip -r "${asset_dir}/${asset_name}" codex-ppt \
+              -x "codex-ppt/.DS_Store" \
+              -x "codex-ppt/.venv/*" \
+              -x "codex-ppt/**/__pycache__/*" \
+              -x "codex-ppt/**/*.pyc"
+          )
+
+          echo "SKILL_ZIP=${asset_dir}/${asset_name}" >> "$GITHUB_ENV"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -112,4 +133,5 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --title "${TAG_NAME}" \
             --notes-file "${RUNNER_TEMP}/release-notes.md" \
-            --verify-tag
+            --verify-tag \
+            "${SKILL_ZIP}#codex-ppt skill zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Improvements
 
-- Package GitHub Release assets as a skill-only zip for direct manual installation.
+- Package GitHub Release assets as a skill-only zip for direct manual installation. (#20)
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Improvements
+
+- Package GitHub Release assets as a skill-only zip for direct manual installation.
+
 ## 0.3.0
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ npx -y skills@latest add ningzimu/codex-ppt-skill \
 
 安装完成后，重启 Codex 让新 skill 生效。
 
+也可以从 GitHub Releases 下载 `codex-ppt-skill-v*.zip`，解压后把其中的 `codex-ppt` 文件夹放到 `~/.codex/skills/codex-ppt`，然后重启 Codex。
+
 如果你是在本地开发这个仓库，也可以把 skill 目录链接到 Codex skills 目录，方便实时调试修改：
 
 ```bash

--- a/README_en.md
+++ b/README_en.md
@@ -84,6 +84,8 @@ npx -y skills@latest add ningzimu/codex-ppt-skill \
 
 Restart Codex after installation so the new skill is picked up.
 
+You can also download `codex-ppt-skill-v*.zip` from GitHub Releases, unzip it, place the contained `codex-ppt` directory at `~/.codex/skills/codex-ppt`, and then restart Codex.
+
 If you are developing this repository locally, you can instead symlink the skill directory into the Codex skills directory so changes are reflected immediately:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a GitHub Release asset that packages only the codex-ppt skill directory
- document direct zip installation in both READMEs
- add an unreleased changelog entry for the new release asset

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check
- bash -n for each release workflow shell snippet
- generated a local test zip and confirmed every entry is under codex-ppt/