### PR TITLE
fix: show release zip filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,4 +134,4 @@ jobs:
             --title "${TAG_NAME}" \
             --notes-file "${RUNNER_TEMP}/release-notes.md" \
             --verify-tag \
-            "${SKILL_ZIP}#codex-ppt skill zip"
+            "${SKILL_ZIP}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Improvements
 
-- Display GitHub Release skill zip assets with their versioned filenames.
+- Display GitHub Release skill zip assets with their versioned filenames. (#21)
 - Package GitHub Release assets as a skill-only zip for direct manual installation. (#20)
 
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Improvements
 
+- Display GitHub Release skill zip assets with their versioned filenames.
 - Package GitHub Release assets as a skill-only zip for direct manual installation. (#20)
 
 ## 0.3.0


### PR DESCRIPTION
## Summary
- remove the custom GitHub Release asset label so the UI shows the versioned zip filename
- add an unreleased changelog entry for the display-name fix

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check