### PR TITLE
ci: require changelog only for skill changes

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -32,13 +32,10 @@ jobs:
           while IFS= read -r path; do
             [ -n "${path}" ] || continue
             case "${path}" in
-              README.md|README_en.md|skills/**|scripts/**)
+              skills/**)
                 changelog_required=true
-                ;;
-              CHANGELOG.md|.github/**|*.md|docs/**|assets/**)
                 ;;
               *)
-                changelog_required=true
                 ;;
             esac
           done <<< "${changed_files}"


### PR DESCRIPTION
## Summary
- make changelog updates mandatory only when files under `skills/` change
- allow README, docs, assets, scripts, and workflow-only PRs without a changelog entry

## Test
- workflow logic change only; not run locally