### PR TITLE
ci: stop requiring PR numbers in changelog

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Validate changelog entry
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -60,25 +59,17 @@ jobs:
             exit 1
           fi
 
-          pr_pattern="(#${PR_NUMBER})"
-          if ! printf '%s\n' "${added_lines}" | grep -Fq "${pr_pattern}"; then
-            echo "CHANGELOG.md entry must reference this PR as ${pr_pattern}."
-            exit 1
-          fi
-
           node <<'NODE'
           const { execSync } = require("node:child_process");
           const fs = require("node:fs");
 
           const base = process.env.BASE_REF;
-          const pr = process.env.PR_NUMBER;
           const diff = execSync(`git diff --unified=0 origin/${base}...HEAD -- CHANGELOG.md`, {
             encoding: "utf8",
           });
           const changelog = fs.readFileSync("CHANGELOG.md", "utf8").split(/\r?\n/);
-          const prToken = `(#${pr})`;
           let currentLine = 0;
-          const addedPrLines = [];
+          const addedLines = [];
 
           for (const line of diff.split(/\r?\n/)) {
             if (line.startsWith("@@ ")) {
@@ -91,9 +82,7 @@ jobs:
             }
             if (line.startsWith("+")) {
               const text = line.slice(1);
-              if (text.includes(prToken)) {
-                addedPrLines.push({ line: currentLine, text });
-              }
+              addedLines.push({ line: currentLine, text });
               if (currentLine > 0) currentLine += 1;
               continue;
             }
@@ -103,12 +92,12 @@ jobs:
             if (currentLine > 0) currentLine += 1;
           }
 
-          if (addedPrLines.length === 0) {
-            console.error(`No added CHANGELOG.md line references ${prToken}.`);
+          if (addedLines.length === 0) {
+            console.error("No added CHANGELOG.md lines found.");
             process.exit(1);
           }
 
-          for (const entry of addedPrLines) {
+          for (const entry of addedLines) {
             let release = "";
             let subsection = "";
             for (let i = entry.line - 1; i >= 0; i -= 1) {


### PR DESCRIPTION
## Summary
- remove the requirement that changelog entries include the PR number
- keep validation that required changelog entries are added under `## Unreleased` in a `###` subsection

## Test
- workflow logic change only; not run locally