### PR TITLE
ci: ignore changelog section headers during validation

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -82,7 +82,9 @@ jobs:
             }
             if (line.startsWith("+")) {
               const text = line.slice(1);
-              addedLines.push({ line: currentLine, text });
+              if (text.trim() && !text.startsWith("## ") && !text.startsWith("### ")) {
+                addedLines.push({ line: currentLine, text });
+              }
               if (currentLine > 0) currentLine += 1;
               continue;
             }


### PR DESCRIPTION
## Summary
- ignore added `##` and `###` changelog headings when validating changelog entry placement
- keep validating actual added entry lines under `## Unreleased` and a `###` subsection

## Test
- workflow logic change only; not run locally