### PR TITLE
docs: link editable PPT reconstruction skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 - Clarify that PPT style references can be screenshots or full PPT/PDF files, and that reusable styles can be saved into this skill's `references/` directory. (#24)
 - Add a README note about personalizing the codex-ppt workflow and include the good skill design deck. (#22)
-- Add a README tip pointing users to image-to-editable-ppt-skill when they need editable PPT reconstruction.
+- Add a README tip pointing users to image-to-editable-ppt-skill when they need editable PPT reconstruction. (#29)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 - Clarify that PPT style references can be screenshots or full PPT/PDF files, and that reusable styles can be saved into this skill's `references/` directory. (#24)
 - Add a README note about personalizing the codex-ppt workflow and include the good skill design deck. (#22)
+- Add a README tip pointing users to image-to-editable-ppt-skill when they need editable PPT reconstruction.
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 一个面向 Codex 的 PPT 生成 skill，也可在 Claude Code、OpenClaw、Hermes Agent 等支持 `SKILL.md` 的 agent 中使用；在这些非 Codex 环境中通常需要配置 `gpt-image-2` 或第三方 OpenAI 兼容格式的生图 API。它把文章、报告、论文、课程笔记等内容转换成“整页图片式”的演示文稿：先规划大纲和视觉风格，再生成每页幻灯片图片，最后用本地脚本组装为 `.pptx`。
 
+> [!TIP]
+> 本 skill 负责从文章、报告、大纲或想法生成图片式 PPT，适合强视觉表达，但页面元素本身不可直接编辑。如果你需要进一步转换成可编辑 PPT，可以在生成完成后尝试使用 [image-to-editable-ppt-skill](https://github.com/ningzimu/image-to-editable-ppt-skill) 进行转换。
+
 ## 温馨提示
 
 这个 skill 主要给大家提供一个还不错的 PPT 生成流程。为了尽量通用，它的流程设计会稍微复杂一些；复杂也会带来不稳定性或者冗余性。比如它同时兼容 Codex 内置生图和 API/CLI fallback 生图，也会兼容有无子 agent 可用这两种情况，但大部分人日常使用时其实只会固定走其中一条路线。

--- a/README_en.md
+++ b/README_en.md
@@ -4,6 +4,9 @@
 
 A Codex skill for generating PowerPoint decks. It can also be used in Claude Code, OpenClaw, Hermes Agent, and other agents that support `SKILL.md`; these non-Codex environments usually require configuring `gpt-image-2` or a third-party OpenAI-compatible image generation API. It turns articles, reports, papers, course notes, and other source materials into image-based presentations: first plan the outline and visual style, then generate each full-slide image, and finally assemble the images into a `.pptx` file with a local script.
 
+> [!TIP]
+> This skill generates image-based PPT decks from articles, reports, outlines, or ideas. It is suitable for strong visual expression, but slide elements are not directly editable. If you need a more editable PPT, you can try converting the generated deck with [image-to-editable-ppt-skill](https://github.com/ningzimu/image-to-editable-ppt-skill).
+
 ## Friendly Note
 
 This skill is meant to provide a solid PPT generation workflow. To stay broadly useful, the workflow is a little more complex than most people need every day, and that complexity can sometimes add instability or redundant choices. For example, it supports both Codex built-in image generation and API/CLI fallback generation, and it also supports workflows with or without subagents. Most users will eventually use only one of those paths.


### PR DESCRIPTION
## Summary
- Add a README tip that explains generated decks are image-based and not directly editable
- Link users to image-to-editable-ppt-skill for editable PPT reconstruction
- Keep Chinese and English READMEs synchronized

## Verification
- git diff --check -- README.md README_en.md CHANGELOG.md