### PR TITLE
docs: add skill documentation reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Documentation
 
-- Add an update and installation reference to the codex-ppt skill instructions.
+- Add an update and installation reference to the codex-ppt skill instructions. (#36)
 - Add a README callout linking to the pinned community showcase issue. (#35)
 - Add the generated skill duo introduction PDF to the README tips.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Documentation
 
+- Add an update and installation reference to the codex-ppt skill instructions.
 - Add a README callout linking to the pinned community showcase issue. (#35)
 - Add the generated skill duo introduction PDF to the README tips.
 

--- a/skills/codex-ppt/SKILL.md
+++ b/skills/codex-ppt/SKILL.md
@@ -712,3 +712,7 @@ This is an internal setup step for the skill. Do not ask the user to run these c
 - Prefer concrete visual direction over generic words like "beautiful" or "professional".
 - For dense content, split across more slides instead of crowding one slide.
 - Prioritize clarity over decoration.
+
+## Documentation and Updates
+
+For the latest `codex-ppt` skill source, documentation, installation steps, configuration guidance, usage examples, and update notes, see [ningzimu/codex-ppt-skill](https://github.com/ningzimu/codex-ppt-skill) and its repository README.

--- a/skills/codex-ppt/SKILL.md
+++ b/skills/codex-ppt/SKILL.md
@@ -715,4 +715,4 @@ This is an internal setup step for the skill. Do not ask the user to run these c
 
 ## Documentation and Updates
 
-For the latest `codex-ppt` skill source, documentation, installation steps, configuration guidance, usage examples, and update notes, see [ningzimu/codex-ppt-skill](https://github.com/ningzimu/codex-ppt-skill) and its repository README.
+For the latest `codex-ppt` skill source, documentation, installation steps, configuration guidance, usage examples, and update notes, see [ningzimu/codex-ppt-skill](https://github.com/ningzimu/codex-ppt-skill).


### PR DESCRIPTION
## Summary

- Add a documentation and updates section to the codex-ppt skill instructions.
- Link users to the main codex-ppt-skill repository for source, documentation, installation, configuration, examples, and update notes.
- Add an unreleased changelog entry.

## Validation

- Documentation-only change; no tests were run.
