### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.3.2
+
 ### Documentation
 
 - Add an update and installation reference to the codex-ppt skill instructions. (#36)


### PR DESCRIPTION
## Summary

- Move current unreleased documentation entries into the `0.3.2` changelog section.

## Validation

- Changelog-only release prep; no tests were run.
