### PR TITLE
docs: add README QA links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
   - `fix: handle missing image API key`
   - `docs: clarify installation steps`
 - Commit messages, PR titles, changelog entries, and release notes must be written in English.
+- Documentation changes that affect README content must update both `README.md` and `README_en.md` in sync.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ skill 会按以下流程执行：
 - 你也可以提供喜欢的 PPT 风格参考，可以是一张截图、多张截图，或完整 PPT/PDF。建议先让当前 agent 分析参考材料的配色、版式、字体和视觉元素，再按这个风格生成新 PPT。生成满意后，也可以让 agent 把这套风格保存到本技能的 `references/` 目录里，方便以后复用。
 - 如果需要插入论文原图、实验结果图、截图或架构图，可以在大纲中指定这些图片对应的页码和用途。
 
+## QA
+
+- 飞书文档：[codex-ppt 常见问题与使用说明](https://icn42st819e7.feishu.cn/wiki/WKIvw81DqinKzcknjiZcbhTMniW?from=from_copylink)
+
 ## 交流群
 
 扫描二维码加入 Skill 交流群，分享使用经验、反馈问题，并获取更新通知。

--- a/README_en.md
+++ b/README_en.md
@@ -203,6 +203,10 @@ The skill follows this workflow:
 - You can also provide PPT style references you like — a single screenshot, multiple screenshots, or a full PPT/PDF. Ask the current agent to analyze the colors, layout, typography, and visual elements first, then generate a new deck in that style. Once the result looks good, you can ask the agent to save the style into this skill's `references/` directory for future reuse.
 - If you need to include paper figures, experiment charts, screenshots, or architecture diagrams, specify the target slide and role for each image in the outline.
 
+## QA
+
+- Feishu doc: [codex-ppt FAQ and usage notes](https://icn42st819e7.feishu.cn/wiki/WKIvw81DqinKzcknjiZcbhTMniW?from=from_copylink)
+
 ## Community
 
 Scan the QR code to join the Skill community group, share usage experience, report issues, and receive update notices.


### PR DESCRIPTION
## Summary
- Add QA sections with the Feishu document link to both Chinese and English READMEs.
- Document that README content changes must keep both language versions in sync.

## Verification
- Documentation-only change; no tests run.