### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.4.0
+
 ### Improvements
 
 - Add deck-level and slide-level context fields to slide prompt jobs so subagents receive self-contained task packets. (#39)


### PR DESCRIPTION
## Summary
- Promote the v0.4.0 changelog entries from Unreleased to the 0.4.0 release section.

## Verification
- Not run; changelog-only release preparation.