### PR TITLE
fix: support Windows slide state locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ examples/
 !assets/style-previews/*.png
 
 # Test outputs
+tests/
 test_output/
 output/
 temp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Fixes
 
-- Use a cross-platform file lock for slide generation state files so Windows can run state recording scripts.
+- Use a cross-platform file lock for slide generation state files so Windows can run state recording scripts. (#41)
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Fixes
+
+- Use a cross-platform file lock for slide generation state files so Windows can run state recording scripts.
+
 ## 0.4.0
 
 ### Improvements

--- a/skills/codex-ppt/requirements.txt
+++ b/skills/codex-ppt/requirements.txt
@@ -1,3 +1,4 @@
 python-pptx>=1.0.2
 Pillow>=10.0.0
 openai>=2.0.0
+filelock>=3.16.0

--- a/skills/codex-ppt/scripts/slide_run_state.py
+++ b/skills/codex-ppt/scripts/slide_run_state.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
-import fcntl
+from filelock import FileLock
 
 
 ACTIVE_SLIDE_STATUSES = {"dispatched"}
@@ -55,8 +55,7 @@ def locked_json(path: Path, default: Any = None):
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(f".{path.name}.lock")
-    with lock_path.open("a+", encoding="utf-8") as lock_file:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    with FileLock(str(lock_path)):
         data = read_json(path, default=default)
         try:
             yield data
@@ -64,8 +63,6 @@ def locked_json(path: Path, default: Any = None):
             raise
         else:
             write_json(path, data)
-        finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def sha256_file(path: Path) -> str:


### PR DESCRIPTION
## Summary

- Replace the Unix-only fcntl lock with filelock for slide generation state files.
- Add filelock to the codex-ppt shared runtime dependencies.
- Ignore local tests directories used for temporary verification.

## User-visible changes

- Windows users can run slide dispatch/result/blocker state scripts without hitting the missing fcntl module.

## Changelog

- [x] Updated CHANGELOG.md
- [ ] Not needed: internal-only change

## Verification

- python3 -m py_compile skills/codex-ppt/scripts/slide_run_state.py
- python3 -c "from filelock import FileLock; print(FileLock.__name__)"