### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.4.1
+
 ### Fixes
 
 - Use a cross-platform file lock for slide generation state files so Windows can run state recording scripts. (#41)


### PR DESCRIPTION
## Summary

- Add the v0.4.1 changelog section for the Windows slide state locking fix.

## User-visible changes

- Release notes will include the Windows-compatible slide state file lock fix from #41.

## Changelog

- [x] Updated CHANGELOG.md
- [ ] Not needed: internal-only change

## Verification

- python3 -m py_compile skills/codex-ppt/scripts/slide_run_state.py
- bash -n .github/workflows/release.yml .github/workflows/changelog-check.yml .github/workflows/pr-title.yml .github/workflows/publish-clawhub-skill.yml