### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.4.2
+
 ### Documentation
 
 - Expand speaker notes guidance so `speech.md` uses content-specific delivery styles, natural presenter-facing talk tracks, and separate emphasis and pacing cues. (#43)


### PR DESCRIPTION
## Summary
- Move the speaker notes documentation entry from `Unreleased` into a new `0.4.2` changelog section.

## Validation
- Verified the `0.4.2` changelog section exists and includes PR reference `(#43)`.
- `git diff --check`

## Release
- After merge, tag `v0.4.2` to trigger the GitHub Release and ClawHub publish workflows.