### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.4.3
+
 ### Features
 
 - Add a reusable McKinsey style reference and README preview for conclusion-first consulting decks. (#45)


### PR DESCRIPTION
Summary: Move the PR #45 changelog entries from Unreleased into the v0.4.3 release section. Verification: git diff --check.