### PR TITLE
fix: sort slide images by numeric index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Fixes
+
+- Sort slide images by numeric index when assembling decks. (#52)
+
 ### Documentation
 
 - Add README one-sentence install guidance and related project links. (#49)

--- a/skills/codex-ppt/scripts/assemble_ppt.py
+++ b/skills/codex-ppt/scripts/assemble_ppt.py
@@ -65,8 +65,8 @@ def get_slide_images(ppt_project_dir: str) -> List[str]:
             if ext in image_extensions and slide_name_pattern.match(file):
                 image_files.append(file_path)
 
-    # 按文件名排序
-    image_files.sort()
+    # 按文件名排序，解决slide_10排在slide_2前面问题
+    image_files.sort(key = lambda p: int(re.search(r"^slide_(\d+)", p.stem).group(1)))
 
     return image_files
 

--- a/skills/codex-ppt/scripts/assemble_ppt.py
+++ b/skills/codex-ppt/scripts/assemble_ppt.py
@@ -11,7 +11,7 @@ import os
 import re
 import sys
 import tempfile
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 def dependency_hint() -> str:
@@ -35,7 +35,7 @@ def dependency_hint() -> str:
 
 def get_slide_images(ppt_project_dir: str) -> List[str]:
     """
-    获取幻灯片图片文件列表，按文件名排序
+    获取幻灯片图片文件列表，按页码排序
 
     Args:
         ppt_project_dir: PPT 项目目录（包含 origin_image 子目录）
@@ -65,15 +65,14 @@ def get_slide_images(ppt_project_dir: str) -> List[str]:
             if ext in image_extensions and slide_name_pattern.match(file):
                 image_files.append(file_path)
 
-    # 按文件名排序，解决slide_10排在slide_2前面问题
-    image_files.sort(
-    key=lambda p: int(
-        re.search(
-            r"^slide_(\d+)",
-            os.path.splitext(os.path.basename(p))[0],
-        ).group(1)
-    )
-)
+    def slide_sort_key(path: str) -> Tuple[int, str]:
+        filename = os.path.basename(path)
+        stem = os.path.splitext(filename)[0]
+        return (int(re.search(r"^slide_(\d+)", stem).group(1)), filename.lower())
+
+    # 按页码排序，避免 slide_10 排在 slide_2 前面。
+    # 同页码多文件时按文件名稳定排序。
+    image_files.sort(key=slide_sort_key)
 
     return image_files
 
@@ -361,7 +360,7 @@ def main():
 注意：
   - 图片文件必须放在 origin_image 子目录中
   - 只会读取 slide_01.png、slide_02.png 这类正式图片，其他图片会被忽略
-  - 图片文件按文件名排序
+  - 图片文件按页码排序
   - 建议图片文件命名为: slide_01.png, slide_02.png, ...
   - 每张图片会充满整个幻灯片页面
   - 如果项目目录下存在 speech.md，会按 Slide N 标题写入每页备注

--- a/skills/codex-ppt/scripts/assemble_ppt.py
+++ b/skills/codex-ppt/scripts/assemble_ppt.py
@@ -66,7 +66,14 @@ def get_slide_images(ppt_project_dir: str) -> List[str]:
                 image_files.append(file_path)
 
     # 按文件名排序，解决slide_10排在slide_2前面问题
-    image_files.sort(key = lambda p: int(re.search(r"^slide_(\d+)", p.stem).group(1)))
+    image_files.sort(
+    key=lambda p: int(
+        re.search(
+            r"^slide_(\d+)",
+            os.path.splitext(os.path.basename(p))[0],
+        ).group(1)
+    )
+)
 
     return image_files
 


### PR DESCRIPTION
## What

Sort slide image files by their numeric slide index instead of lexicographic filename order.

## Why

The current filename sort may place `slide_10.png` before `slide_2.png` when slide files are not zero-padded.

## Changes

- Sort matched slide files using the numeric index from `slide_N.*`
- Preserve existing support for zero-padded names like `slide_01.png`

## Tested

- Ran `python skills/codex-ppt/scripts/assemble_ppt.py --help`
- Manually checked ordering for `slide_1.png`, `slide_2.png`, and `slide_10.png`