### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Release notes are generated from this file. Keep changelog entries in English.
 
-## Unreleased
+## 0.4.4
 
 ### Fixes
 


### PR DESCRIPTION
## Summary
- Promote the current changelog entries to version 0.4.4.

## Verification
- Checked the 0.4.4 changelog section locally.

## Notes
- GitHub Release and ClawHub publish workflows will run from tag v0.4.4 after merge.