### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.5.0
+
 ### Features
 
 - Add an AtlasCloud image provider adapter for GPT Image 2 generation and editing. (#60)


### PR DESCRIPTION
## Summary
- Move the current Unreleased changelog entries into the 0.5.0 release section.

## Verification
- Ran local release-note extraction for version 0.5.0.
- Ran `git diff --check`.