### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.5.2
+
 ### Fixes
 
 - Revert the codex-ppt skill contents to the v0.5.0 release state. (#67)


### PR DESCRIPTION
## Summary
- Move the rollback changelog entry into the `0.5.2` release section

## Verification
- `git diff --name-status v0.5.0..HEAD -- ':!CHANGELOG.md'`
- Local release-notes extraction check for `0.5.2`
- `git diff --check`

## Notes
- Skill contents remain identical to the v0.5.0 release state apart from changelog history.