### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Documentation
+
+- Add Autohand Code install and usage notes. (#73)
+
 ## 0.5.2
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![English](https://img.shields.io/badge/docs-English-blue)](README_en.md) [![ClawHub](https://img.shields.io/badge/ClawHub-codex--ppt-cd3b35)](https://clawhub.ai/ningzimu/codex-ppt) [![GitHub stars](https://img.shields.io/github/stars/ningzimu/codex-ppt-skill?style=flat&logo=github&label=stars)](https://github.com/ningzimu/codex-ppt-skill/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ningzimu/codex-ppt-skill?style=flat&logo=github&label=forks)](https://github.com/ningzimu/codex-ppt-skill/forks)
 
-一个面向 Codex 的 PPT 生成 skill，也可在 Claude Code、OpenClaw、Hermes Agent 等支持 `SKILL.md` 的 agent 中使用；在这些非 Codex 环境中通常需要配置 `gpt-image-2`、第三方生图 API 或 OpenAI 兼容格式的生图接口。它把文章、报告、论文、课程笔记等内容转换成“整页图片式”的演示文稿：先规划大纲和视觉风格，再生成每页幻灯片图片，最后用本地脚本组装为 `.pptx`。
+一个面向 Codex 的 PPT 生成 skill，也可在 Claude Code、OpenClaw、Autohand Code、Hermes Agent 等支持 `SKILL.md` 的 agent 中使用；在这些非 Codex 环境中通常需要配置 `gpt-image-2`、第三方生图 API 或 OpenAI 兼容格式的生图接口。它把文章、报告、论文、课程笔记等内容转换成“整页图片式”的演示文稿：先规划大纲和视觉风格，再生成每页幻灯片图片，最后用本地脚本组装为 `.pptx`。
 
 ## 赞助
 
@@ -35,7 +35,7 @@
 
 ## 特点
 
-- 多 agent 可用：支持 Codex、Claude Code、OpenClaw、Hermes Agent 等支持 `SKILL.md` 的环境；最推荐在 Codex 中使用，优先走内置生图和编辑图能力。
+- 多 agent 可用：支持 Codex、Claude Code、OpenClaw、Autohand Code、Hermes Agent 等支持 `SKILL.md` 的环境；最推荐在 Codex 中使用，优先走内置生图和编辑图能力。
 - 第三方生图供应商接入：支持 OpenAI 兼容接口、AtlasCloud、`base URL` 和自定义模型名配置，方便通过 API/CLI fallback 使用 `gpt-image-2` 或兼容模型。
 - 稳定的阶段化流程：先确认大纲、页数、视觉风格、生图后端和样张，再进入整套生成，降低一次生成完整 PPT 时的返工和偏航。
 - 不是无脑生成：会先引导你确认 `outline.md`、每页要点、风格方向和样张效果，再按确认后的方案继续。
@@ -167,6 +167,28 @@ npx -y skills@latest add ningzimu/codex-ppt-skill \
 
 如果你是在本地开发这个仓库，也可以用软链接替代复制，方便实时调试修改。
 
+### Autohand Code
+
+Autohand Code 可以读取 `SKILL.md` 形式的 skill。手动安装到用户级目录：
+
+```bash
+git clone https://github.com/ningzimu/codex-ppt-skill.git
+mkdir -p ~/.autohand/skills
+cp -R codex-ppt-skill/skills/codex-ppt ~/.autohand/skills/
+```
+
+安装到当前项目目录：
+
+```bash
+git clone https://github.com/ningzimu/codex-ppt-skill.git
+mkdir -p .autohand/skills
+cp -R codex-ppt-skill/skills/codex-ppt .autohand/skills/
+```
+
+如果这个 skill 后续发布到 Autohand Skills 索引，也可以用 `autohand --skill-install codex-ppt` 安装到用户级目录，或加 `--project` 安装到当前项目。
+
+在 Autohand Code 中使用时，和其他非 Codex 环境一样，请确认当前环境有可用的图片生成后端，或按需配置 `gpt-image-2` / OpenAI 兼容接口。
+
 ## 生图模型配置
 
 > [!TIP]
@@ -179,7 +201,7 @@ npx -y skills@latest add ningzimu/codex-ppt-skill \
 
 ## 使用方式
 
-在 Codex、Claude Code、OpenClaw 或 Hermes Agent 中明确指定使用 `codex-ppt` skill，例如：
+在 Codex、Claude Code、OpenClaw、Autohand Code 或 Hermes Agent 中明确指定使用 `codex-ppt` skill，例如：
 
 ```text
 请使用 codex-ppt skill 把 /path/to/article.md 做成 10 页左右的 PPT。

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 
 [![中文](https://img.shields.io/badge/docs-中文-red)](README.md) [![ClawHub](https://img.shields.io/badge/ClawHub-codex--ppt-cd3b35)](https://clawhub.ai/ningzimu/codex-ppt) [![GitHub stars](https://img.shields.io/github/stars/ningzimu/codex-ppt-skill?style=flat&logo=github&label=stars)](https://github.com/ningzimu/codex-ppt-skill/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ningzimu/codex-ppt-skill?style=flat&logo=github&label=forks)](https://github.com/ningzimu/codex-ppt-skill/forks)
 
-A Codex skill for generating PowerPoint decks. It can also be used in Claude Code, OpenClaw, Hermes Agent, and other agents that support `SKILL.md`; these non-Codex environments usually require configuring `gpt-image-2`, a third-party image API, or an OpenAI-compatible image generation endpoint. It turns articles, reports, papers, course notes, and other source materials into image-based presentations: first plan the outline and visual style, then generate each full-slide image, and finally assemble the images into a `.pptx` file with a local script.
+A Codex skill for generating PowerPoint decks. It can also be used in Claude Code, OpenClaw, Autohand Code, Hermes Agent, and other agents that support `SKILL.md`; these non-Codex environments usually require configuring `gpt-image-2`, a third-party image API, or an OpenAI-compatible image generation endpoint. It turns articles, reports, papers, course notes, and other source materials into image-based presentations: first plan the outline and visual style, then generate each full-slide image, and finally assemble the images into a `.pptx` file with a local script.
 
 ## Sponsor
 
@@ -35,7 +35,7 @@ For a basic introduction to skill design and usage, see [good-skill-design.pptx]
 
 ## Features
 
-- Works across multiple agents: supports Codex, Claude Code, OpenClaw, Hermes Agent, and other `SKILL.md`-based environments; Codex is the recommended environment because it can use the built-in image generation and image editing tools first.
+- Works across multiple agents: supports Codex, Claude Code, OpenClaw, Autohand Code, Hermes Agent, and other `SKILL.md`-based environments; Codex is the recommended environment because it can use the built-in image generation and image editing tools first.
 - Supports third-party image providers: works with OpenAI-compatible endpoints, AtlasCloud, `base URL`, and custom model names, so API/CLI fallback can use `gpt-image-2` or compatible image models.
 - Stable staged workflow: confirms the outline, slide count, visual style, image backend, and sample slide before full-deck generation, reducing drift and rework when generating a complete PPT.
 - Guided instead of one-shot: the skill asks you to confirm `outline.md`, per-slide key points, style direction, and sample-slide quality before continuing.
@@ -167,6 +167,28 @@ Common target directories are `~/.claude/skills/codex-ppt` for Claude Code and `
 
 If you are developing this repository locally, you can use a symlink instead of copying so changes are reflected immediately.
 
+### Autohand Code
+
+Autohand Code can read `SKILL.md` skills. To install manually at user level:
+
+```bash
+git clone https://github.com/ningzimu/codex-ppt-skill.git
+mkdir -p ~/.autohand/skills
+cp -R codex-ppt-skill/skills/codex-ppt ~/.autohand/skills/
+```
+
+To install into the current project:
+
+```bash
+git clone https://github.com/ningzimu/codex-ppt-skill.git
+mkdir -p .autohand/skills
+cp -R codex-ppt-skill/skills/codex-ppt .autohand/skills/
+```
+
+If this skill is later published to an Autohand Skills index, users can install the cataloged skill with `autohand --skill-install codex-ppt`, or add `--project` to install it into the current project.
+
+When using Autohand Code, confirm that the current environment has an image generation backend available, or configure `gpt-image-2` / an OpenAI-compatible endpoint as needed, just like other non-Codex environments.
+
 ## Image Model Configuration
 
 > [!TIP]
@@ -179,7 +201,7 @@ Asking for a specific resolution, higher quality, or edits to one slide does not
 
 ## Usage
 
-Ask Codex, Claude Code, OpenClaw, or Hermes Agent and explicitly specify the `codex-ppt` skill, for example:
+Ask Codex, Claude Code, OpenClaw, Autohand Code, or Hermes Agent and explicitly specify the `codex-ppt` skill, for example:
 
 ```text
 Use the codex-ppt skill to turn /path/to/article.md into a roughly 10-slide PPT.


### PR DESCRIPTION
## Summary

- Add Autohand Code to the existing multi-agent support wording.
- Document user-level and project-level Autohand Code install paths for the `codex-ppt` skill.
- Keep the same image-backend caveat used for other non-Codex environments.

## User-visible changes

- Readers can now install `codex-ppt` under `~/.autohand/skills/` or `.autohand/skills/`.
- README usage text now lists Autohand Code alongside Codex, Claude Code, OpenClaw, and Hermes Agent.

## Changelog

- [x] Updated `CHANGELOG.md`
- [ ] Not needed: internal-only change

## Verification

- `git diff --check`