### PR TITLE
chore: release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.5.4
+
 ### Features
 
 - Add a reusable Party-and-Government Red style reference and preview for formal public-sector presentations. (#79)


### PR DESCRIPTION
## Summary

- promote the two unreleased built-in style entries into the `0.5.4` changelog section
- prepare tag-driven GitHub Release and ClawHub publishing

## Verification

- extracted the `0.5.4` changelog section with the release workflow logic
- confirmed both release entries include PR references
- ran `git diff --check`

## Notes

- release contents come from PR #79
- local `outputs/` artifacts are not included