### PR TITLE
feat: refine party-government red and teaching styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ examples/
 # Test outputs
 tests/
 test_output/
-output/
+outputs/
 temp/
 
 # macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Improvements
+
+- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance.
+
 ## 0.5.4
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Improvements
 
-- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance.
+- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance. (#82)
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 ### Improvements
 
 - Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance.
+- Make the Teaching Courseware style more adaptable across disciplines by removing example-specific subject matter, fixed module counts, and repetitive card-grid assumptions.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Improvements
 
-- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance.
-- Make the Teaching Courseware style more adaptable across disciplines by removing example-specific subject matter, fixed module counts, and repetitive card-grid assumptions.
+- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance. (#82)
+- Make the Teaching Courseware style more adaptable across disciplines by removing example-specific subject matter, fixed module counts, and repetitive card-grid assumptions. (#82)
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Improvements
 
-- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance. (#82)
+- Make the Party-and-Government Red style more adaptable by replacing fixed layout and motif prescriptions with content-driven visual guidance.
 
 ## 0.5.4
 

--- a/skills/codex-ppt/references/党政红风格.md
+++ b/skills/codex-ppt/references/党政红风格.md
@@ -11,12 +11,12 @@
   "type": "16:9 full-slide PowerPoint image",
   "style_name": "党政红风格",
   "best_for": "党政机关、国企和事业单位的工作汇报、政策宣讲、党建学习、年度总结与重点工作部署",
-  "visual_direction": "solemn and dignified Chinese government-report presentation, confident Chinese-red and gold visual identity, strong title hierarchy, restrained ceremonial details, and clear policy communication",
+  "visual_direction": "solemn, authoritative, and optimistic Chinese public-sector presentation with a recognizable Chinese-red identity, restrained gold accents, strong Chinese typography, and a visual expression shaped by the subject rather than a fixed ceremonial layout",
   "canvas": {
     "aspect_ratio": "16:9",
-    "background": "choose deep red, warm ivory, or a restrained combination according to page role and content density; where appropriate, use a low-contrast pale-gold landscape or Great Wall motif near the lower area as a subtle unifying background element that never competes with the content",
-    "composition": "formal, balanced, and strongly aligned composition with a prominent title area and disciplined content hierarchy",
-    "density": "medium information density with generous margins, clear reading order, and concise conclusions"
+    "background": "choose red, warm ivory, a restrained gradient, a relevant photograph, or a subtle abstract treatment according to the page role and subject; any landscape, architecture, ribbon, skyline, or cultural motif is optional and must serve the content rather than become a default background",
+    "composition": "formal and balanced with a prominent title hierarchy and disciplined alignment; allow centered, asymmetric, image-led, modular, or spacious compositions when they better express the content",
+    "density": "medium information density with controlled whitespace, clear reading order, and enough supporting text or evidence to make each page useful"
   },
   "color_palette": {
     "primary": "Chinese red #C41E3A for main titles, structural emphasis, and key labels",
@@ -33,65 +33,65 @@
   },
   "title_system": {
     "consistency_rule": "Keep the title hierarchy, typeface, weight, color logic, and spacing consistent across slides of the same page type.",
-    "cover": "May use a more ceremonial and prominent title treatment suited to an opening page.",
-    "section_divider": "May use a concise title treatment with stronger whitespace and a clear section cue.",
-    "content_slide": "Prefer an optional restrained section-navigation cue, a prominent centered main title, and a small gold separator. Keep the hierarchy recognizable across content slides while adapting its exact form, scale, and spacing to the page content.",
-    "flexibility": "Treat this as a visual consistency guide, not a fixed template. Title position and decoration may adapt when the slide role or composition requires it."
+    "cover": "Use a prominent, dignified title treatment that may be centered, offset, or integrated with a relevant visual according to the composition.",
+    "section_divider": "Use a concise title and a clear transition in scale, color, whitespace, or imagery without requiring a fixed navigation bar or ornament.",
+    "content_slide": "Keep the page topic immediately recognizable, but align the title with the composition and information structure; centered and left-aligned treatments are both valid.",
+    "flexibility": "Treat the title system as a hierarchy and consistency rule, not a fixed arrangement. Do not require a navigation strip, centered title, gold separator, numbering style, or identical decoration on every slide."
   },
   "layout_patterns": [
-    "ceremonial cover with a large prominent title and restrained red-and-gold visual framing",
-    "section divider with a concise statement, clear section cue, and generous negative space",
-    "policy overview with one core statement and three to five aligned content modules",
-    "key work deployment with clear priorities, concise explanations, and a strong bottom conclusion",
-    "timeline or process page using a restrained red-and-gold hierarchy",
-    "achievement summary with large key figures, restrained charts, and evidence-based captions"
+    "cover or opener with a dominant title and a subject-relevant photographic, illustrative, architectural, landscape, or abstract visual",
+    "section divider with a concise statement and a clear transition created through scale, whitespace, color, or imagery",
+    "content explanation organized around the most important relationship, argument, process, comparison, or evidence",
+    "work deployment or policy interpretation page whose modules, sequence, and emphasis follow the source content",
+    "achievement or data page combining key figures, charts, images, and evidence-based captions as needed",
+    "summary or closing page that reinforces the central message with a strong but restrained visual conclusion"
   ],
-  "layout_usage_rule": "Keep the red-and-gold identity consistent while varying covers, dividers, content grids, timelines, and data pages by purpose. Use light backgrounds for dense content instead of forcing every slide onto solid red.",
+  "layout_usage_rule": "Keep the red-led identity, typography, and formal tone consistent while varying title placement, background treatment, imagery, information structure, and whitespace by page purpose. Do not force every slide into the same grid, module count, title position, or decorative motif; use lighter backgrounds when they improve readability.",
   "layout_blueprints": [
     {
-      "name": "封面 / 章节页",
+      "name": "封面 / 开场",
       "sections": [
-        {"position": "center", "count": 1, "labels": ["large formal title"]},
-        {"position": "below title", "count": 1, "labels": ["subtitle or reporting unit and date"]},
-        {"position": "bottom", "count": 1, "labels": ["subtle ribbon, Great Wall, or abstract architectural horizon"]}
+        {"position": "primary visual field", "count": 1, "labels": ["prominent title and concise supporting information"]},
+        {"position": "supporting field", "count": 1, "labels": ["optional subject-relevant photograph, illustration, architecture, landscape, or abstract visual"]}
       ]
     },
     {
-      "name": "重点工作部署",
+      "name": "信息阐释 / 工作部署",
       "sections": [
-        {"position": "top", "count": 1, "labels": ["page title and one-sentence guiding statement"]},
-        {"position": "middle", "count": 4, "labels": ["重点一", "重点二", "重点三", "重点四"]},
-        {"position": "bottom", "count": 1, "labels": ["summary or action requirement"]}
+        {"position": "title zone", "count": 1, "labels": ["clear page topic or guiding statement"]},
+        {"position": "main content field", "count": 1, "labels": ["the dominant argument, relationship, process, comparison, or evidence structure"]},
+        {"position": "supporting field", "count": 1, "labels": ["supporting text, data, images, or callouts selected according to the source"]}
       ]
     },
     {
-      "name": "成果与数据",
+      "name": "成果 / 总结",
       "sections": [
-        {"position": "top", "count": 1, "labels": ["page title"]},
-        {"position": "upper middle", "count": 3, "labels": ["key figure 1", "key figure 2", "key figure 3"]},
-        {"position": "lower middle", "count": 1, "labels": ["restrained chart, comparison, or timeline"]},
-        {"position": "bottom", "count": 1, "labels": ["evidence-based conclusion"]}
+        {"position": "primary message field", "count": 1, "labels": ["central conclusion, achievement, or call to action"]},
+        {"position": "evidence field", "count": 1, "labels": ["figures, chart, comparison, documentary image, or concise supporting points as appropriate"]}
       ]
     }
   ],
   "visual_elements": {
-    "allowed": "restrained red-and-gold geometric accents, formal information modules, timelines, process arrows, simple line icons, clean charts, subtle Chinese cultural or architectural motifs, and light decorative texture",
-    "avoid": "invented government or party logos, national emblems, seals, flags, hammer-and-sickle symbols, excessive ceremonial decoration, thick shadows, glossy 3D text, glitter, lanterns, fireworks, wedding motifs, Lunar New Year decoration, cartoon characters, and unrelated stock imagery"
+    "allowed": "content-relevant photography, illustrations, landscapes, architecture, skylines, public-service scenes, people, abstract ribbons or color fields, restrained red-and-gold accents, formal information modules, simple icons, clean charts, and subtle cultural motifs; none of these elements is mandatory",
+    "avoid": "repeating the same landmark or ornament without content justification, invented or inaccurate official marks, excessive ceremonial decoration, thick shadows, glossy 3D text, glitter, festival or wedding motifs, cartoon styling, unrelated stock imagery, and decorative elements that compete with the message"
   },
   "image_treatment": {
-    "photos": "use only relevant user-provided documentary or institutional photos; apply consistent red-toned framing rather than heavy color filters",
+    "photos": "use relevant and credible documentary, landscape, architectural, public-service, or institutional imagery; it may be full-bleed, cropped, framed, or integrated with a restrained red treatment, but avoid heavy filters that obscure the subject",
     "screenshots": "place inside clean warm-white frames with short source labels and no ornamental clutter",
     "charts": "use red as the primary series, gold for one key highlight, and neutral gray for comparison; keep labels direct and readable",
-    "illustrations": "prefer flat architectural silhouettes, abstract ribbons, restrained line art, or policy-related diagrams instead of decorative scenes"
+    "illustrations": "choose a flat, graphic, painterly, or restrained symbolic treatment according to the subject; do not impose a fixed landmark, ribbon, skyline, or landscape motif",
+    "official_symbols": "use a party emblem, national emblem, flag, seal, or other official symbol only when the content genuinely requires it and an accurate, authorized source asset is available; never invent, approximate, or redesign official symbols"
   },
   "rendering_constraints": [
     "The slide must look like a formal Chinese government or public-sector report, not a festival poster or commercial advertisement.",
     "Use large, dignified Chinese sans-serif typography resembling Microsoft YaHei or Source Han Sans.",
     "Follow a consistent title system across slides of the same page type, while allowing cover, section-divider, and content-slide variants.",
+    "Let the page role and source content determine title placement, background, imagery, module count, and composition.",
+    "Do not force a navigation strip, centered title, gold separator, landscape, Great Wall, skyline, ribbon, or other specific motif onto every slide.",
     "Use Chinese red #C41E3A as the main red and gold as a restrained supporting accent.",
     "Keep gold restrained and matte; do not use glossy metallic or embossed 3D text.",
     "Use exact readable Chinese text and a clear top-to-bottom or left-to-right hierarchy.",
-    "Do not invent official marks, government logos, party emblems, national emblems, seals, flags, or institutional names.",
+    "Do not invent, approximate, or redesign official marks, government logos, party emblems, national emblems, seals, flags, or institutional names.",
     "No watermark and no unrelated logo."
   ]
 }

--- a/skills/codex-ppt/references/教学课件风.md
+++ b/skills/codex-ppt/references/教学课件风.md
@@ -12,11 +12,11 @@
   "type": "16:9 full-slide PowerPoint image",
   "style_name": "教学课件风",
   "best_for": "高校课程、专题讲座、技术培训、知识科普、概念讲解、体系梳理、案例分析和研究进展介绍",
-  "visual_direction": "clear and credible academic courseware, structured knowledge communication, modular information design, evidence-supported explanation, and a professional classroom tone",
+  "visual_direction": "clear and credible academic courseware with structured knowledge communication, evidence-supported explanation, discipline-appropriate visuals, and a professional classroom tone shaped by the lesson rather than a fixed technical template",
   "canvas": {
     "aspect_ratio": "16:9",
     "background": "white or very light cool gray with restrained pale-blue structural accents",
-    "composition": "structured teaching slide with a clear title area, modular knowledge blocks, diagrams, evidence images, or comparisons selected according to the lesson objective",
+    "composition": "structured teaching slide with a clear title hierarchy and a content-driven combination of text, images, diagrams, charts, formulas, source material, annotations, or comparisons selected according to the lesson objective",
     "density": "balanced teaching density: substantial enough to support explanation, but never sparse, paragraph-heavy, or crowded; use strong grouping, alignment, and readable whitespace"
   },
   "color_palette": {
@@ -29,76 +29,78 @@
   "typography": {
     "title": "large bold Chinese sans-serif resembling Microsoft YaHei or Source Han Sans, usually dark navy, concise and immediately readable",
     "body": "compact but readable Chinese sans-serif with clear indentation and short explanatory phrases",
-    "labels": "bold short labels with strong contrast inside restrained color-coded blocks",
+    "labels": "bold short labels with strong contrast, used when hierarchy or semantic categories need clarification rather than as mandatory card decoration",
     "text_quality": "all Chinese text, Latin terms, formulas, units, and data labels must be exact, readable, and non-garbled"
   },
   "title_system": {
     "consistency_rule": "Keep title typeface, weight, color logic, alignment, and spacing consistent across slides of the same page type.",
-    "cover": "May combine a large course title with one strong topic image and concise presenter or course information.",
+    "cover": "May combine a large course title with one or more subject-relevant visuals and concise presenter or course information; choose the visual structure according to the discipline and topic.",
     "section_divider": "May use a concise section title with stronger whitespace and a restrained academic cue.",
-    "content_slide": "Prefer a stable, prominent title area with a subtle blue rule or structural accent, while allowing the exact alignment and composition to adapt to the teaching content.",
-    "closing": "Use a concise acknowledgement or closing statement together with a topic-relevant visual echo; keep the page informative and visually complete rather than leaving a nearly empty text-only slide.",
-    "flexibility": "Treat the title system as a consistency guide rather than a fixed template. Do not force every slide into the same header composition."
+    "content_slide": "Keep the page topic immediately recognizable, but let title alignment, supporting accents, and surrounding composition adapt to the teaching content.",
+    "closing": "Use a concise acknowledgement or closing statement together with a subject-relevant visual or summary echo; keep the page informative and visually complete rather than leaving a nearly empty text-only slide.",
+    "flexibility": "Treat the title system as a consistency guide rather than a fixed template. Do not force every slide into the same header, rule, alignment, or decorative treatment."
   },
   "layout_patterns": [
-    "course cover combining a clear title hierarchy with a topic-relevant main visual and concise course information",
-    "concept explanation using a central model and surrounding factors",
-    "development stages or maturity levels using a clear progression",
-    "process or workflow explanation combining steps, diagrams, and evidence",
-    "comparison or relationship page using aligned modules and semantic colors",
-    "case study combining a key image with maps, metrics, observations, and conclusions",
-    "application overview using a structured gallery of examples",
-    "knowledge summary using a concise framework and one clear takeaway",
-    "closing or acknowledgement page combining a short closing statement with a restrained topic-relevant visual"
+    "course cover combining a clear title hierarchy with subject-relevant visual material and concise course information",
+    "concept explanation using the most suitable combination of diagrams, images, definitions, formulas, source excerpts, or annotated examples",
+    "sequence, process, development, or causal explanation with a clear viewing order",
+    "comparison or relationship page whose structure follows the concepts being contrasted or connected",
+    "case, text, artwork, experiment, event, or application analysis supported by relevant evidence and explanation",
+    "overview or synthesis page organizing examples, themes, findings, or knowledge relationships",
+    "knowledge summary using a concise framework, conclusion, or takeaway",
+    "closing or acknowledgement page combining a short closing statement with a restrained subject-relevant visual"
   ],
-  "layout_usage_rule": "Choose the layout that best supports the teaching objective and viewing sequence. Every slide should combine meaningful visual explanation with readable text; use one strong image or several complementary images, diagrams, screenshots, or charts according to the content. Keep the visual language coherent without repeating one composition on every slide.",
+  "layout_usage_rule": "Choose the layout that best supports the teaching objective and viewing sequence. Every slide should combine meaningful visual explanation with readable text; use one strong visual or several complementary photographs, diagrams, charts, maps, formulas, documents, artworks, screenshots, or annotated examples according to the discipline and content. Keep the visual language coherent without forcing every page into cards, equal columns, or one repeated composition.",
   "layout_blueprints": [
     {
-      "name": "概念与体系",
+      "name": "概念 / 知识讲解",
       "sections": [
         {"position": "title area", "count": 1, "labels": ["lesson question or core concept"]},
-        {"position": "main area", "count": 1, "labels": ["system diagram or concept model"]},
-        {"position": "supporting area", "count": 2, "labels": ["definition or explanation", "key takeaway or implication"]}
+        {"position": "primary teaching field", "count": 1, "labels": ["the most suitable visual and explanatory structure for the concept"]},
+        {"position": "supporting field", "count": 1, "labels": ["definitions, examples, evidence, annotations, or implications as needed"]}
       ]
     },
     {
-      "name": "流程与阶段",
+      "name": "过程 / 关系讲解",
       "sections": [
-        {"position": "title area", "count": 1, "labels": ["process or progression topic"]},
-        {"position": "main area", "count": 1, "labels": ["ordered stages, workflow, or maturity progression"]},
-        {"position": "supporting area", "count": 1, "labels": ["conditions, risks, or summary"]}
+        {"position": "title area", "count": 1, "labels": ["process, development, comparison, or relationship topic"]},
+        {"position": "primary relationship field", "count": 1, "labels": ["sequence, cause, contrast, hierarchy, interaction, or transformation"]},
+        {"position": "supporting field", "count": 1, "labels": ["conditions, examples, evidence, annotations, or summary as needed"]}
       ]
     },
     {
-      "name": "案例与证据",
+      "name": "案例 / 材料 / 证据",
       "sections": [
-        {"position": "title area", "count": 1, "labels": ["case or application topic"]},
-        {"position": "evidence area", "count": 2, "labels": ["primary image or map", "data, facts, or observations"]},
-        {"position": "conclusion area", "count": 1, "labels": ["lesson learned or teaching conclusion"]}
+        {"position": "context field", "count": 1, "labels": ["case, text, event, artwork, experiment, or application context"]},
+        {"position": "evidence field", "count": 1, "labels": ["relevant visual material, source excerpt, data, observations, or comparison"]},
+        {"position": "teaching conclusion field", "count": 1, "labels": ["interpretation, lesson learned, or takeaway"]}
       ]
     }
   ],
   "visual_elements": {
-    "allowed": "relevant photographs, multi-image evidence groups, clean line icons, modular cards, process arrows, relationship diagrams, level progressions, maps, timelines, annotated technical images, comparison grids, data charts, and subtle academic or technical background texture",
-    "avoid": "text-only pages, purely decorative illustration, generic AI-looking imagery, fake futuristic interfaces, random 3D icons, playful stickers, excessive gradients, heavy shadows, glossy elements, inconsistent icon styles, dense ungrouped text, unrelated stock imagery, and ornamental layouts that weaken the teaching sequence"
+    "allowed": "discipline-relevant photographs, artworks, archival documents, source excerpts, maps, formulas, tables, charts, diagrams, screenshots, multi-image evidence groups, annotated images, timelines, relationship structures, restrained icons, and subtle academic background texture; cards and grids may be used when they genuinely clarify the material but are not the default",
+    "avoid": "text-only pages, purely decorative illustration, repetitive card grids, default three-column layouts, generic AI-looking imagery, unsupported futuristic or technical styling, random 3D icons, playful stickers, excessive gradients, heavy shadows, glossy elements, inconsistent icon styles, dense ungrouped text, unrelated stock imagery, and ornamental layouts that weaken the teaching sequence"
   },
   "image_treatment": {
-    "photos": "use relevant course or case images as evidence, crop them consistently, and pair them with concise explanatory labels; one page may use a single main image or several complementary images when they explain different aspects of the topic",
+    "photos": "use relevant and credible course or case images as evidence, crop them consistently, and pair them with concise explanatory labels; one page may use a single main image or several complementary images when they explain different aspects of the topic",
     "screenshots": "place inside clean frames and preserve important interface details, annotations, and labels",
     "charts": "use the palette semantically, retain accurate axes and values, and emphasize the comparison or trend being taught",
-    "illustrations": "prefer flat technical diagrams, simplified system models, and explanatory line art over decorative scenes"
+    "illustrations": "choose diagrams, maps, explanatory drawings, documentary collage, symbolic graphics, or other illustration treatments appropriate to the discipline and lesson; avoid decorative scenes that do not teach anything",
+    "discipline_materials": "treat formulas, artworks, historical documents, literary excerpts, medical images, scientific figures, and other subject-specific materials as valid visual evidence when relevant and accurately represented"
   },
   "rendering_constraints": [
     "The slide must look like professional academic courseware, not a marketing pitch deck.",
     "Prioritize teaching sequence, conceptual clarity, and readable evidence over visual decoration.",
     "Every slide must contain both meaningful visual content and readable text; visuals should explain, demonstrate, compare, or provide evidence rather than merely decorate.",
+    "Visual content may include photographs, diagrams, charts, maps, formulas, artworks, documents, source excerpts, screenshots, or other discipline-appropriate material; it does not always mean a decorative illustration.",
     "Avoid both underfilled slides and long blocks of prose. Convert dense explanations into diagrams, image groups, structured labels, or concise teaching points.",
     "Keep related information visibly grouped and maintain a clear viewing order.",
     "Avoid tiny text; split or simplify content when it cannot remain readable at presentation distance.",
     "Use semantic accent colors consistently across the deck.",
+    "Do not force every slide into repeated cards, equal columns, a fixed module count, or an identical information grid.",
     "Avoid an obvious AI-generated look: no fabricated text inside images, implausible photo details, generic glowing technology effects, random decorative objects, or repetitive template-like compositions.",
     "Do not invent university, school, laboratory, company, or course logos; use only user-provided identity assets.",
-    "Do not introduce vehicles, autonomous-driving imagery, or other subject matter from the style reference unless required by the source content.",
+    "Do not inherit topics, examples, imagery, terminology, or organizations from a style reference unless they are required by the source content.",
     "No watermark and no unrelated logo."
   ]
 }


### PR DESCRIPTION
## Summary

- Make the Party-and-Government Red style content-driven instead of prescribing fixed title positions, motifs, and module counts.
- Broaden the Teaching Courseware style across disciplines, remove reference-topic leakage, and avoid repetitive card-grid defaults.
- Ignore the generated outputs directory without mixing that maintenance change into the style commits.

## Verification

- Extracted both JSON style briefs and validated them with jq.
- Ran git diff --check.

## Notes

- README preview images are unchanged.