### PR TITLE
chore: release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.5.5
+
 ### Features
 
 - Store user custom styles in `${CODEX_PPT_HOME:-~/.codex-ppt-skill}/references/` outside the skill install so they survive skill updates and reinstalls, with automatic discovery and same-name priority over built-in styles. (#83)


### PR DESCRIPTION
将 Unreleased 中的条目归入 0.5.5 版本段，准备 tag 驱动的 GitHub Release。

包含变更：个人风格库外部持久化（#83）、党政红与教学课件风格调优（#82）、文档站补全与 README 更新（#83）。