### PR TITLE
feat: add HTML-first slide skill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,14 @@ jobs:
 
           (
             cd skills
-            zip -r "${asset_dir}/${asset_name}" codex-ppt \
+            zip -r "${asset_dir}/${asset_name}" codex-ppt codex-html-slides \
               -x "codex-ppt/.DS_Store" \
               -x "codex-ppt/.venv/*" \
               -x "codex-ppt/**/__pycache__/*" \
-              -x "codex-ppt/**/*.pyc"
+              -x "codex-ppt/**/*.pyc" \
+              -x "codex-html-slides/.DS_Store" \
+              -x "codex-html-slides/**/__pycache__/*" \
+              -x "codex-html-slides/**/*.pyc"
           )
 
           echo "SKILL_ZIP=${asset_dir}/${asset_name}" >> "$GITHUB_ENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Features
+
+- Add the standalone `codex-html-slides` skill for image-quality, self-contained HTML presentations built from editable DOM, CSS, and inline SVG, with 12 native style recipes, a reusable presentation runtime, and deterministic validation.
+
 ## 0.5.5
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Features
 
-- Add the standalone `codex-html-slides` skill for image-quality, self-contained HTML presentations built from editable DOM, CSS, and inline SVG, with 12 native style recipes, a reusable presentation runtime, and deterministic validation.
+- Add the standalone `codex-html-slides` skill for image-quality, self-contained HTML presentations built from editable DOM, CSS, and inline SVG, with 12 native style recipes, a reusable presentation runtime, and deterministic validation. (#88)
 
 ## 0.5.5
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@
 
 一个面向 Codex 的 PPT 生成 skill，也可在 Claude Code、OpenClaw、Hermes Agent 等支持 `SKILL.md` 的 agent 中使用；在这些非 Codex 环境中通常需要配置 `gpt-image-2`、第三方生图 API 或 OpenAI 兼容格式的生图接口。它把文章、报告、论文、课程笔记等内容转换成“整页图片式”的演示文稿：先规划大纲和视觉风格，再生成每页幻灯片图片，最后用本地脚本组装为 `.pptx`。
 
+## HTML-first 演示 Skill
+
+仓库同时提供独立的 [`codex-html-slides`](skills/codex-html-slides/SKILL.md) skill。它只输出一个可离线播放的自包含 HTML 文件，不调用生图模型，也不生成整页 PNG、JPG、PPTX 或 PDF。每页都使用可编辑的 HTML、CSS 和内联 SVG 构建，并通过固定 1600×900 画布、浏览器等比缩放、排版层级、纹理、裁切、图表和 SVG 插画，尽量复刻图片式 PPT 的视觉质感。
+
+|  | `codex-ppt` | `codex-html-slides` |
+| --- | --- | --- |
+| 最终产物 | 图片式 `.pptx` | 单个自包含 `.html` |
+| 页面实现 | 每页完整生成图片 | DOM + CSS + 内联 SVG |
+| 生图模型 | 需要 | 不需要 |
+| 页面元素 | 不可直接编辑 | 可直接编辑源码 |
+
+单独安装 HTML skill：
+
+```bash
+npx -y skills@latest add ningzimu/codex-ppt-skill \
+  --skill codex-html-slides \
+  --agent codex \
+  --global
+```
+
+使用示例：
+
+```text
+请使用 codex-html-slides skill，把 /path/to/article.md 做成 10 页、自包含的 HTML 演示文稿，视觉风格参考我提供的截图，但不要生成页面图片。
+```
+
 ## 赞助
 
 <table>

--- a/README_en.md
+++ b/README_en.md
@@ -4,6 +4,32 @@
 
 A Codex skill for generating PowerPoint decks. It can also be used in Claude Code, OpenClaw, Hermes Agent, and other agents that support `SKILL.md`; these non-Codex environments usually require configuring `gpt-image-2`, a third-party image API, or an OpenAI-compatible image generation endpoint. It turns articles, reports, papers, course notes, and other source materials into image-based presentations: first plan the outline and visual style, then generate each full-slide image, and finally assemble the images into a `.pptx` file with a local script.
 
+## HTML-first Presentation Skill
+
+This repository also includes the standalone [`codex-html-slides`](skills/codex-html-slides/SKILL.md) skill. It outputs one offline-ready, self-contained HTML file, does not call an image-generation model, and does not generate full-slide PNG, JPEG, PPTX, or PDF files. Every page is built from editable HTML, CSS, and inline SVG. A fixed 1600×900 canvas, uniform browser scaling, typographic hierarchy, texture, cropping, charts, and SVG illustration help it reproduce the visual finish of image-based decks.
+
+|  | `codex-ppt` | `codex-html-slides` |
+| --- | --- | --- |
+| Final output | Image-based `.pptx` | One self-contained `.html` |
+| Slide implementation | One generated image per page | DOM + CSS + inline SVG |
+| Image model | Required | Not required |
+| Page elements | Not directly editable | Editable in source |
+
+Install only the HTML skill:
+
+```bash
+npx -y skills@latest add ningzimu/codex-ppt-skill \
+  --skill codex-html-slides \
+  --agent codex \
+  --global
+```
+
+Example request:
+
+```text
+Use the codex-html-slides skill to turn /path/to/article.md into a 10-slide, self-contained HTML presentation. Reproduce the visual style of my reference screenshot without generating slide images.
+```
+
 ## Sponsor
 
 <table>

--- a/skills/codex-html-slides/SKILL.md
+++ b/skills/codex-html-slides/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: codex-html-slides
+description: Create polished, self-contained HTML presentations from articles, reports, papers, notes, outlines, PDFs, Word documents, or reference decks. Use when Codex needs to build, restyle, or revise a browser-playable 16:9 slide deck whose pages remain editable as HTML/CSS/inline SVG, especially when the user wants image-quality visual styling without generating full-slide PNG, JPEG, WebP, PPTX, or PDF outputs.
+---
+
+# Codex HTML Slides
+
+## Output contract
+
+Create one browser-playable `.html` file by default. Build every slide from editable DOM, CSS, and inline SVG on a fixed 1600×900 canvas that scales to the viewport.
+
+Do not:
+
+- call an image-generation backend;
+- generate or save full-slide PNG, JPEG, WebP, GIF, PDF, or PPTX files;
+- use a screenshot, canvas export, or rasterized reference page as a slide background;
+- hide a bitmap of a completed slide inside HTML;
+- add CDN, web-font, framework, or network dependencies unless the user explicitly accepts a non-self-contained deck.
+
+User-supplied figures, photos, logos, and screenshots may appear as content assets when required. Preserve them faithfully, fit the layout around them, and embed them as data URIs when the final file must remain self-contained. Never treat one supplied image as the entire slide.
+
+## Required references
+
+- Read `references/visual-system.md` before deriving a style or authoring the sample slide.
+- Read `references/style-recipes.md` when using a built-in direction or translating an image-style deck into CSS/SVG.
+- Read `references/qa.md` before final validation and delivery.
+
+## Workflow
+
+1. Understand the source.
+   - Identify topic, audience, purpose, language, desired slide count, presentation setting, and mandatory content.
+   - Inspect supplied files and distinguish style references from content assets.
+
+2. Confirm the outline.
+   - Draft slide titles, roles, core message, evidence, and intended visual mechanism.
+   - Vary roles across cover, section divider, thesis, comparison, process, framework, data, evidence, and closing slides.
+   - Ask the user to approve the outline before producing a non-trivial deck.
+
+3. Confirm the visual system.
+   - If the user supplies a reference image, PDF, PPT, or PPTX, analyze its geometry, palette, typography, shape language, depth, texture, image treatment, and information density. Recreate the system; never reuse a full rendered page as a background.
+   - Otherwise offer two or three concrete directions from `references/style-recipes.md`, recommend one, and confirm it.
+   - Define CSS tokens for palette, type scale, spacing, radii, borders, shadows, and motion before styling individual slides.
+
+4. Initialize the deck.
+   - Run:
+
+     ```bash
+     python3 scripts/create_deck.py /absolute/path/deck.html \
+       --title "Deck title" --lang zh-CN --theme clean-professional
+     ```
+
+   - Keep the template runtime and replace the sample content rather than rebuilding navigation from scratch.
+
+5. Build and approve one sample slide.
+   - Implement exactly one representative slide using final DOM/CSS/SVG techniques.
+   - Preview it at 1600×900 and at the user's likely display size.
+   - Confirm hierarchy, density, visual fidelity, and text accuracy before expanding the deck.
+
+6. Build the complete deck.
+   - Add one `<section class="slide" data-slide>` per page.
+   - Keep the visual identity consistent while giving each slide a content-driven composition.
+   - Use inline SVG for diagrams, illustrations, texture, masks, charts, and hand-drawn effects. Keep text as real HTML or SVG text when practical.
+   - Embed speaker notes in `<aside class="speaker-notes">` when notes are requested.
+
+7. Verify interaction and layout.
+   - Preserve keyboard, touch, fullscreen, hash navigation, notes, progress, reduced-motion, and print behavior from the template.
+   - Run the bundled validator, then inspect every slide in a browser as required by `references/qa.md`.
+
+8. Deliver.
+   - Report the absolute HTML path, slide count, selected visual direction, self-contained status, validation result, and any intentionally external assets.
+
+## Slide authoring standard
+
+Use this structure for every page:
+
+```html
+<section class="slide" id="slide-2" data-slide aria-labelledby="slide-2-title">
+  <div class="slide-content layout-comparison">
+    <p class="eyebrow">SECTION / 02</p>
+    <h2 id="slide-2-title">A conclusion-led title</h2>
+    <!-- semantic HTML and inline SVG -->
+  </div>
+  <aside class="speaker-notes">Optional presenter-only notes.</aside>
+</section>
+```
+
+Follow these rules:
+
+- Keep slide coordinates deterministic. Compose inside 1600×900; let the runtime scale the stage.
+- Use a clear reading order and one dominant visual idea per slide.
+- Keep titles concise and body copy presentation-sized. Split content instead of shrinking it.
+- Prefer purposeful grids, editorial composition, diagrams, and scale contrast over repetitive rounded cards.
+- Make diagrams explain relationships. Connectors, labels, arrows, legends, and emphasis must encode meaning.
+- Use exact user text, names, numbers, citations, and official marks. Do not invent evidence or logos.
+- Keep decorative elements `aria-hidden="true"`; label meaningful diagrams and controls.
+- Use theme variables and reusable classes instead of scattered one-off colors.
+
+## Image-quality styling without slide images
+
+Translate image aesthetics into native layers:
+
+- Composition: asymmetric grids, cropping, overlap, focal axes, strong negative space, and deliberate edge tension.
+- Typography: extreme but controlled scale contrast, editorial line breaks, optical alignment, and a consistent title system.
+- Depth: restrained shadows, translucent planes, borders, blur, and foreground/background separation.
+- Texture: CSS gradients, repeating patterns, blend modes, and inline SVG filters rather than raster grain files.
+- Illustration: inline SVG paths, symbols, patterns, clipping, markers, and controlled irregularity.
+- Data: semantic HTML tables or SVG charts with direct labels and a visible conclusion.
+- Motion: short state transitions that support hierarchy; never depend on animation to reveal essential content.
+
+The result should feel art-directed like a high-quality rendered slide, but remain inspectable and editable as HTML.
+
+## Revision rules
+
+Revise the source DOM, CSS variables, layout classes, or inline SVG. Never repair a page by screenshotting it and replacing the slide with an `<img>` element. Re-run validation and browser QA after any structural or style revision.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/validate_deck.py /absolute/path/deck.html \
+  --expect-slides 10 --strict
+```
+
+Acceptance requires:
+
+- a valid self-contained HTML document;
+- the expected number of uniquely identified 16:9 slides;
+- no full-slide raster references or `origin_image` pipeline;
+- no external scripts, stylesheets, fonts, frames, or media unless explicitly approved;
+- functional navigation and readable content at the required viewport sizes;
+- no clipping, accidental overflow, console errors, or hidden essential content;
+- consistent visual identity with varied, content-driven layouts.
+

--- a/skills/codex-html-slides/agents/openai.yaml
+++ b/skills/codex-html-slides/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex HTML Slides"
+  short_description: "Build image-quality, self-contained HTML decks"
+  default_prompt: "Use $codex-html-slides to turn my source material into a polished, self-contained HTML presentation."

--- a/skills/codex-html-slides/assets/deck-template.html
+++ b/skills/codex-html-slides/assets/deck-template.html
@@ -1,0 +1,729 @@
+<!doctype html>
+<html lang="{{DECK_LANG}}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="color-scheme" content="dark light">
+  <title>{{DECK_TITLE}}</title>
+  <style>
+    :root {
+      --canvas-width: 1600px;
+      --canvas-height: 900px;
+      --deck-scale: 1;
+      --font-sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-serif: Georgia, "Songti SC", "STSong", serif;
+      --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      --stage-shadow: 0 32px 100px rgb(5 15 35 / 34%);
+      color-scheme: light;
+    }
+
+    * { box-sizing: border-box; }
+
+    html,
+    body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      background: #090e19;
+      color: #eef3fb;
+      font-family: var(--font-sans);
+    }
+
+    button { font: inherit; }
+
+    .viewport {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 15% 18%, rgb(57 86 150 / 22%), transparent 28%),
+        radial-gradient(circle at 86% 76%, rgb(64 47 122 / 18%), transparent 30%),
+        #090e19;
+    }
+
+    .stage {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: var(--canvas-width);
+      height: var(--canvas-height);
+      overflow: hidden;
+      transform: translate(-50%, -50%) scale(var(--deck-scale));
+      transform-origin: center center;
+      background: var(--bg);
+      box-shadow: var(--stage-shadow);
+      isolation: isolate;
+    }
+
+    .deck {
+      width: 100%;
+      height: 100%;
+      background: var(--bg);
+      color: var(--ink);
+    }
+
+    .deck[data-theme="clean-professional"] {
+      --bg: #f7f9fc;
+      --surface: #ffffff;
+      --ink: #152238;
+      --muted: #667085;
+      --accent: #2563eb;
+      --accent-2: #06b6d4;
+      --accent-soft: #dbeafe;
+      --line: #d9e2ef;
+      --radius: 24px;
+      --panel-shadow: 0 24px 70px rgb(37 99 235 / 12%);
+      --display-font: var(--font-sans);
+    }
+
+    .deck[data-theme="creative-magazine"] {
+      --bg: #f8f6f1;
+      --surface: #ffffff;
+      --ink: #111111;
+      --muted: #5f5f5f;
+      --accent: #ff006e;
+      --accent-2: #111111;
+      --accent-soft: #ffd7e8;
+      --line: #161616;
+      --radius: 0px;
+      --panel-shadow: 12px 12px 0 #111111;
+      --display-font: var(--font-serif);
+    }
+
+    .deck[data-theme="e-ink-magazine"] {
+      --bg: #f3f0e8;
+      --surface: #faf8f2;
+      --ink: #1b1b1b;
+      --muted: #77736a;
+      --accent: #c44736;
+      --accent-2: #44423e;
+      --accent-soft: #ead9d0;
+      --line: #2d2c29;
+      --radius: 2px;
+      --panel-shadow: 0 14px 30px rgb(27 27 27 / 10%);
+      --display-font: var(--font-serif);
+    }
+
+    .deck[data-theme="data-dashboard"] {
+      --bg: #08111f;
+      --surface: #111d2e;
+      --ink: #e7eef8;
+      --muted: #91a4bd;
+      --accent: #22d3ee;
+      --accent-2: #34d399;
+      --accent-soft: #113647;
+      --line: #28415d;
+      --radius: 18px;
+      --panel-shadow: 0 22px 65px rgb(0 0 0 / 32%);
+      --display-font: var(--font-sans);
+      color-scheme: dark;
+    }
+
+    .deck[data-theme="retro-flat"] {
+      --bg: #f5f3e8;
+      --surface: #fffaf0;
+      --ink: #34495e;
+      --muted: #6c7a89;
+      --accent: #ff6b6b;
+      --accent-2: #95e1d3;
+      --accent-soft: #f9e29a;
+      --line: #263747;
+      --radius: 14px;
+      --panel-shadow: 9px 9px 0 rgb(38 55 71 / 16%);
+      --display-font: var(--font-serif);
+    }
+
+    .deck[data-theme="handdrawn-technical"] {
+      --bg: #fcfbf7;
+      --surface: #fffefa;
+      --ink: #2f3437;
+      --muted: #6f7476;
+      --accent: #7ba8d1;
+      --accent-2: #9fbea4;
+      --accent-soft: #dce9f5;
+      --line: #4d5356;
+      --radius: 9px;
+      --panel-shadow: 5px 7px 0 rgb(47 52 55 / 8%);
+      --display-font: var(--font-sans);
+    }
+
+    .deck[data-theme="handdrawn-whiteboard"] {
+      --bg: #fffefa;
+      --surface: #ffffff;
+      --ink: #202124;
+      --muted: #6f7378;
+      --accent: #4285f4;
+      --accent-2: #34a853;
+      --accent-soft: #dbe7fd;
+      --line: #202124;
+      --radius: 7px;
+      --panel-shadow: 4px 6px 0 rgb(32 33 36 / 9%);
+      --display-font: var(--font-sans);
+    }
+
+    .deck[data-theme="warm-handmade"] {
+      --bg: #f7efe3;
+      --surface: #fffaf2;
+      --ink: #4a3728;
+      --muted: #7d6857;
+      --accent: #c96c4b;
+      --accent-2: #7a8b58;
+      --accent-soft: #eed6bf;
+      --line: #8c715d;
+      --radius: 5px;
+      --panel-shadow: 10px 14px 28px rgb(74 55 40 / 15%);
+      --display-font: var(--font-serif);
+    }
+
+    .deck[data-theme="scientific-defense"] {
+      --bg: #ffffff;
+      --surface: #f8fbfe;
+      --ink: #102a43;
+      --muted: #5d7184;
+      --accent: #145da0;
+      --accent-2: #c62828;
+      --accent-soft: #dceaf5;
+      --line: #c7d5e3;
+      --radius: 8px;
+      --panel-shadow: 0 16px 38px rgb(20 93 160 / 11%);
+      --display-font: var(--font-sans);
+    }
+
+    .deck[data-theme="consulting"] {
+      --bg: #f6f8fa;
+      --surface: #ffffff;
+      --ink: #243447;
+      --muted: #6b7280;
+      --accent: #527896;
+      --accent-2: #111111;
+      --accent-soft: #e5edf3;
+      --line: #cfd8e3;
+      --radius: 2px;
+      --panel-shadow: 0 18px 46px rgb(36 52 71 / 9%);
+      --display-font: var(--font-sans);
+    }
+
+    .deck[data-theme="party-red"] {
+      --bg: #fff9f2;
+      --surface: #ffffff;
+      --ink: #262626;
+      --muted: #665c56;
+      --accent: #c41e3a;
+      --accent-2: #d6a84b;
+      --accent-soft: #f5d7dc;
+      --line: #c9b8aa;
+      --radius: 6px;
+      --panel-shadow: 0 18px 44px rgb(158 21 48 / 12%);
+      --display-font: var(--font-sans);
+    }
+
+    .deck[data-theme="teaching-courseware"] {
+      --bg: #f8fbf7;
+      --surface: #ffffff;
+      --ink: #24332c;
+      --muted: #66756c;
+      --accent: #2f7d5c;
+      --accent-2: #e58c3a;
+      --accent-soft: #ddefe6;
+      --line: #cbded4;
+      --radius: 18px;
+      --panel-shadow: 0 18px 45px rgb(47 125 92 / 11%);
+      --display-font: var(--font-sans);
+    }
+
+    .slide {
+      position: absolute;
+      inset: 0;
+      width: var(--canvas-width);
+      height: var(--canvas-height);
+      overflow: hidden;
+      visibility: hidden;
+      opacity: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at 83% 18%, color-mix(in srgb, var(--accent) 15%, transparent), transparent 28%),
+        linear-gradient(145deg, var(--bg), color-mix(in srgb, var(--bg) 86%, var(--accent-soft)));
+      transition: opacity 280ms ease, visibility 280ms ease;
+    }
+
+    .slide.is-active {
+      z-index: 1;
+      visibility: visible;
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .slide::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      opacity: .3;
+      background-image:
+        linear-gradient(color-mix(in srgb, var(--line) 10%, transparent) 1px, transparent 1px),
+        linear-gradient(90deg, color-mix(in srgb, var(--line) 10%, transparent) 1px, transparent 1px);
+      background-size: 48px 48px;
+      mask-image: linear-gradient(100deg, transparent 4%, black 45%, transparent 92%);
+    }
+
+    .slide-content {
+      position: absolute;
+      inset: 72px 96px 76px;
+      z-index: 2;
+      display: grid;
+      grid-template-columns: minmax(0, 1.04fr) minmax(470px, .96fr);
+      gap: 68px;
+      align-items: center;
+    }
+
+    .slide-copy { align-self: center; }
+
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin: 0 0 28px;
+      color: var(--accent);
+      font-family: var(--font-mono);
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+
+    .eyebrow::before {
+      content: "";
+      width: 54px;
+      height: 4px;
+      background: var(--accent);
+    }
+
+    h1 {
+      max-width: 860px;
+      margin: 0;
+      color: var(--ink);
+      font-family: var(--display-font);
+      font-size: 98px;
+      font-weight: 760;
+      letter-spacing: -.055em;
+      line-height: .98;
+      text-wrap: balance;
+    }
+
+    .lede {
+      max-width: 780px;
+      margin: 34px 0 0;
+      color: var(--muted);
+      font-size: 31px;
+      line-height: 1.48;
+      text-wrap: pretty;
+    }
+
+    .signal-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+      margin: 38px 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .signal-list li {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 12px 18px;
+      background: color-mix(in srgb, var(--surface) 82%, transparent);
+      color: var(--ink);
+      font-family: var(--font-mono);
+      font-size: 18px;
+      letter-spacing: .025em;
+    }
+
+    .visual-system {
+      position: relative;
+      width: 560px;
+      height: 560px;
+      justify-self: end;
+      border: 1px solid color-mix(in srgb, var(--line) 75%, transparent);
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at center, color-mix(in srgb, var(--accent) 20%, transparent), transparent 16%),
+        radial-gradient(circle at 68% 28%, color-mix(in srgb, var(--accent-2) 22%, transparent), transparent 19%),
+        color-mix(in srgb, var(--surface) 72%, transparent);
+      box-shadow: var(--panel-shadow);
+    }
+
+    .visual-system::before,
+    .visual-system::after {
+      content: "";
+      position: absolute;
+      border: 1px solid color-mix(in srgb, var(--line) 64%, transparent);
+      border-radius: inherit;
+    }
+
+    .visual-system::before { inset: 56px; }
+    .visual-system::after { inset: 124px; border-style: dashed; }
+
+    .visual-system svg {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      overflow: visible;
+    }
+
+    .orbit-line {
+      fill: none;
+      stroke: var(--line);
+      stroke-width: 2;
+      stroke-dasharray: 7 10;
+    }
+
+    .orbit-path {
+      fill: none;
+      stroke: var(--accent);
+      stroke-width: 5;
+      stroke-linecap: round;
+    }
+
+    .orbit-node { fill: var(--surface); stroke: var(--accent); stroke-width: 4; }
+    .orbit-node.is-alt { stroke: var(--accent-2); }
+
+    .system-label {
+      position: absolute;
+      display: grid;
+      min-width: 138px;
+      gap: 4px;
+      border-left: 4px solid var(--accent);
+      padding: 12px 14px;
+      background: color-mix(in srgb, var(--surface) 90%, transparent);
+      box-shadow: 0 10px 24px rgb(0 0 0 / 8%);
+    }
+
+    .system-label strong { color: var(--ink); font-size: 22px; }
+    .system-label span { color: var(--muted); font-family: var(--font-mono); font-size: 15px; }
+    .system-label.one { top: 52px; right: -24px; }
+    .system-label.two { bottom: 74px; right: -38px; border-color: var(--accent-2); }
+    .system-label.three { bottom: 48px; left: -28px; }
+
+    .chapter-mark {
+      position: absolute;
+      right: 42px;
+      bottom: 32px;
+      z-index: 3;
+      color: color-mix(in srgb, var(--muted) 72%, transparent);
+      font-family: var(--font-mono);
+      font-size: 16px;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+
+    .speaker-notes { display: none; }
+
+    .controls {
+      position: fixed;
+      left: 50%;
+      bottom: max(16px, env(safe-area-inset-bottom));
+      z-index: 20;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      transform: translateX(-50%);
+      border: 1px solid rgb(255 255 255 / 14%);
+      border-radius: 999px;
+      padding: 7px;
+      background: rgb(9 14 25 / 80%);
+      box-shadow: 0 14px 36px rgb(0 0 0 / 32%);
+      backdrop-filter: blur(18px);
+    }
+
+    .controls button {
+      display: grid;
+      width: 42px;
+      height: 42px;
+      place-items: center;
+      border: 0;
+      border-radius: 50%;
+      background: transparent;
+      color: #f4f7fb;
+      cursor: pointer;
+    }
+
+    .controls button:hover,
+    .controls button:focus-visible { background: rgb(255 255 255 / 12%); outline: none; }
+
+    .controls svg { width: 20px; height: 20px; fill: currentColor; }
+
+    .counter {
+      min-width: 72px;
+      color: #f4f7fb;
+      font-family: var(--font-mono);
+      font-size: 14px;
+      text-align: center;
+    }
+
+    .progress {
+      position: fixed;
+      inset: 0 0 auto;
+      z-index: 30;
+      height: 3px;
+      background: rgb(255 255 255 / 9%);
+    }
+
+    .progress::after {
+      content: "";
+      display: block;
+      width: var(--progress, 0%);
+      height: 100%;
+      background: linear-gradient(90deg, #5da8ff, #74f0d1);
+      transition: width 220ms ease;
+    }
+
+    .notes-panel {
+      position: fixed;
+      top: 18px;
+      right: 18px;
+      z-index: 40;
+      display: none;
+      width: min(440px, calc(100vw - 36px));
+      max-height: calc(100vh - 110px);
+      overflow: auto;
+      border: 1px solid rgb(255 255 255 / 16%);
+      border-radius: 18px;
+      padding: 22px 24px;
+      background: rgb(9 14 25 / 92%);
+      color: #f5f7fb;
+      font-size: 18px;
+      line-height: 1.55;
+      box-shadow: 0 24px 70px rgb(0 0 0 / 38%);
+      backdrop-filter: blur(20px);
+    }
+
+    .notes-panel.is-open { display: block; }
+    .notes-panel h2 { margin: 0 0 12px; font-size: 18px; }
+    .notes-panel p { margin: 0; color: #cfd8e8; }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        scroll-behavior: auto !important;
+        transition-duration: .001ms !important;
+        animation-duration: .001ms !important;
+        animation-iteration-count: 1 !important;
+      }
+    }
+
+    @page { size: 13.333in 7.5in; margin: 0; }
+
+    @media print {
+      html,
+      body {
+        width: auto;
+        height: auto;
+        overflow: visible;
+        background: #fff;
+      }
+
+      .viewport { position: static; overflow: visible; background: #fff; }
+      .stage { position: static; width: 1600px; height: auto; transform: none !important; box-shadow: none; }
+      .deck { height: auto; }
+      .slide {
+        position: relative;
+        display: block;
+        visibility: visible;
+        width: 1600px;
+        height: 900px;
+        opacity: 1;
+        break-after: page;
+        page-break-after: always;
+      }
+      .controls, .progress, .notes-panel { display: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <div class="viewport">
+    <main class="stage" aria-label="{{DECK_TITLE}} presentation">
+      <div class="deck" data-deck data-theme="{{DECK_THEME}}">
+        <section class="slide is-active" id="slide-1" data-slide aria-labelledby="slide-1-title">
+          <div class="slide-content">
+            <div class="slide-copy">
+              <p class="eyebrow">HTML-FIRST / 01</p>
+              <h1 id="slide-1-title">{{DECK_TITLE}}</h1>
+              <p class="lede">Replace this sample with one precise message. Keep the page native, editable, and visually art-directed.</p>
+              <ul class="signal-list" aria-label="Presentation qualities">
+                <li>DOM</li>
+                <li>CSS</li>
+                <li>INLINE SVG</li>
+              </ul>
+            </div>
+
+            <div class="visual-system" aria-label="Native HTML visual system">
+              <svg viewBox="0 0 560 560" role="img" aria-labelledby="visual-system-title">
+                <title id="visual-system-title">Three connected native layers: structure, style, and motion</title>
+                <defs>
+                  <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"></path>
+                  </marker>
+                </defs>
+                <circle class="orbit-line" cx="280" cy="280" r="226"></circle>
+                <path class="orbit-path" d="M110 300 C155 140 344 92 454 205 C505 257 470 390 352 444" marker-end="url(#arrow)"></path>
+                <circle class="orbit-node" cx="126" cy="248" r="18"></circle>
+                <circle class="orbit-node is-alt" cx="405" cy="154" r="18"></circle>
+                <circle class="orbit-node" cx="388" cy="421" r="18"></circle>
+              </svg>
+              <div class="system-label one"><strong>Structure</strong><span>semantic DOM</span></div>
+              <div class="system-label two"><strong>Expression</strong><span>CSS + SVG</span></div>
+              <div class="system-label three"><strong>Delivery</strong><span>single HTML</span></div>
+            </div>
+          </div>
+
+          <p class="chapter-mark">1600 × 900 / EDITABLE BY DESIGN</p>
+          <aside class="speaker-notes">Introduce the deck's central promise and explain why a native HTML presentation remains easier to inspect, revise, and deliver.</aside>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  <div class="progress" aria-hidden="true"></div>
+
+  <nav class="controls" aria-label="Presentation controls">
+    <button type="button" data-action="previous" aria-label="Previous slide" title="Previous slide (←)">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.4 5.4 8.8 12l6.6 6.6-1.4 1.4L6 12l8-8 1.4 1.4Z"></path></svg>
+    </button>
+    <span class="counter" data-counter aria-live="polite">1 / 1</span>
+    <button type="button" data-action="next" aria-label="Next slide" title="Next slide (→)">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.6 18.6 6.6-6.6-6.6-6.6L10 4l8 8-8 8-1.4-1.4Z"></path></svg>
+    </button>
+    <button type="button" data-action="notes" aria-label="Toggle speaker notes" title="Speaker notes (N)">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm2 5v2h10V8H7Zm0 4v2h10v-2H7Zm0 4v2h6v-2H7Z"></path></svg>
+    </button>
+    <button type="button" data-action="fullscreen" aria-label="Toggle fullscreen" title="Fullscreen (F)">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h6v2H6v4H4V4Zm10 0h6v6h-2V6h-4V4Zm4 10h2v6h-6v-2h4v-4ZM4 14h2v4h4v2H4v-6Z"></path></svg>
+    </button>
+  </nav>
+
+  <aside class="notes-panel" data-notes-panel aria-live="polite" aria-label="Current slide speaker notes">
+    <h2>Speaker notes</h2>
+    <p data-notes-content></p>
+  </aside>
+
+  <p class="sr-only" data-live-region aria-live="polite"></p>
+
+  <script>
+    (() => {
+      const stage = document.querySelector('.stage');
+      const slides = [...document.querySelectorAll('[data-slide]')];
+      const counter = document.querySelector('[data-counter]');
+      const notesPanel = document.querySelector('[data-notes-panel]');
+      const notesContent = document.querySelector('[data-notes-content]');
+      const liveRegion = document.querySelector('[data-live-region]');
+      let index = Math.max(0, slides.findIndex((slide) => `#${slide.id}` === location.hash));
+      let pointerStart = null;
+
+      const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+      function resizeStage() {
+        const padding = 20;
+        const scale = Math.min(
+          (window.innerWidth - padding * 2) / 1600,
+          (window.innerHeight - padding * 2) / 900
+        );
+        document.documentElement.style.setProperty('--deck-scale', Math.max(.1, scale).toFixed(5));
+      }
+
+      function updateNotes() {
+        const notes = slides[index]?.querySelector('.speaker-notes');
+        notesContent.textContent = notes?.textContent.trim() || 'No speaker notes for this slide.';
+      }
+
+      function showSlide(next, updateHash = true) {
+        index = clamp(next, 0, slides.length - 1);
+        slides.forEach((slide, slideIndex) => {
+          const active = slideIndex === index;
+          slide.classList.toggle('is-active', active);
+          slide.setAttribute('aria-hidden', String(!active));
+          if ('inert' in slide) slide.inert = !active;
+        });
+
+        counter.textContent = `${index + 1} / ${slides.length}`;
+        document.documentElement.style.setProperty('--progress', `${((index + 1) / slides.length) * 100}%`);
+        updateNotes();
+        liveRegion.textContent = `Slide ${index + 1} of ${slides.length}: ${slides[index].textContent.trim().slice(0, 90)}`;
+
+        if (updateHash) history.replaceState(null, '', `#${slides[index].id}`);
+      }
+
+      function toggleNotes() {
+        notesPanel.classList.toggle('is-open');
+      }
+
+      async function toggleFullscreen() {
+        if (!document.fullscreenElement) await document.documentElement.requestFullscreen?.();
+        else await document.exitFullscreen?.();
+      }
+
+      document.querySelector('[data-action="previous"]').addEventListener('click', () => showSlide(index - 1));
+      document.querySelector('[data-action="next"]').addEventListener('click', () => showSlide(index + 1));
+      document.querySelector('[data-action="notes"]').addEventListener('click', toggleNotes);
+      document.querySelector('[data-action="fullscreen"]').addEventListener('click', toggleFullscreen);
+
+      document.addEventListener('keydown', (event) => {
+        if (/^(INPUT|TEXTAREA|SELECT)$/.test(event.target.tagName) || event.target.isContentEditable) return;
+        if (['ArrowRight', 'ArrowDown', 'PageDown', ' '].includes(event.key)) {
+          event.preventDefault();
+          showSlide(index + 1);
+        } else if (['ArrowLeft', 'ArrowUp', 'PageUp'].includes(event.key)) {
+          event.preventDefault();
+          showSlide(index - 1);
+        } else if (event.key === 'Home') {
+          event.preventDefault();
+          showSlide(0);
+        } else if (event.key === 'End') {
+          event.preventDefault();
+          showSlide(slides.length - 1);
+        } else if (event.key.toLowerCase() === 'f') {
+          event.preventDefault();
+          toggleFullscreen();
+        } else if (event.key.toLowerCase() === 'n') {
+          event.preventDefault();
+          toggleNotes();
+        }
+      });
+
+      window.addEventListener('hashchange', () => {
+        const target = slides.findIndex((slide) => `#${slide.id}` === location.hash);
+        if (target >= 0) showSlide(target, false);
+      });
+
+      window.addEventListener('resize', resizeStage, { passive: true });
+      window.addEventListener('pointerdown', (event) => {
+        pointerStart = { x: event.clientX, y: event.clientY };
+      }, { passive: true });
+      window.addEventListener('pointerup', (event) => {
+        if (!pointerStart) return;
+        const dx = event.clientX - pointerStart.x;
+        const dy = event.clientY - pointerStart.y;
+        pointerStart = null;
+        if (Math.abs(dx) > 72 && Math.abs(dx) > Math.abs(dy) * 1.25) showSlide(index + (dx < 0 ? 1 : -1));
+      }, { passive: true });
+
+      resizeStage();
+      showSlide(index, false);
+    })();
+  </script>
+</body>
+</html>
+

--- a/skills/codex-html-slides/references/qa.md
+++ b/skills/codex-html-slides/references/qa.md
@@ -1,0 +1,59 @@
+# HTML deck QA
+
+Run both deterministic validation and browser inspection. Passing the script does not prove that a slide is visually correct.
+
+## Deterministic validation
+
+Run:
+
+```bash
+python3 scripts/validate_deck.py /absolute/path/deck.html \
+  --expect-slides <count> --strict
+```
+
+Resolve every error. Resolve warnings unless the user explicitly approved the exception.
+
+## Browser inspection
+
+Open the HTML directly or serve its directory with:
+
+```bash
+python3 -m http.server 8000 --directory /absolute/path/to/deck-directory
+```
+
+Inspect every slide at these viewport sizes:
+
+- 1600×900: design coordinate baseline.
+- 1366×768: common laptop presentation viewport.
+- 390×844: confirm the scaled stage remains reachable on mobile.
+
+Transient browser screenshots may be used for inspection, but do not save or deliver raster slide files.
+
+Check:
+
+- no title, label, axis, source, or required image is clipped;
+- no text block overlaps another element;
+- body text is presentation-readable and line breaks are intentional;
+- the primary message is obvious within three seconds;
+- adjacent slides do not repeat the same composition mechanically;
+- palette, typography, stroke language, and spacing remain coherent;
+- required facts, names, numbers, citations, and assets are exact;
+- decorative SVG does not capture pointer events or pollute accessibility output;
+- keyboard navigation works for arrows, Page Up/Down, Space, Home, and End;
+- fullscreen and notes toggles work;
+- the URL hash opens the requested slide;
+- reduced-motion mode remains usable;
+- browser console shows no uncaught errors or failed asset requests;
+- print preview places one 16:9 slide per page without controls.
+
+## Revision threshold
+
+Regenerate the composition, rather than applying tiny patches, when a slide has more than one of these problems:
+
+- content only fits by using text below 24 px;
+- the reading order is ambiguous;
+- the reference style is recognizable only by color;
+- more than six equal-weight modules compete for attention;
+- the dominant diagram does not communicate a relationship;
+- the slide resembles a web dashboard when the chosen direction is editorial, illustrative, academic, or consulting.
+

--- a/skills/codex-html-slides/references/style-recipes.md
+++ b/skills/codex-html-slides/references/style-recipes.md
@@ -1,0 +1,115 @@
+# Native HTML style recipes
+
+## Contents
+
+1. Clean professional
+2. Creative magazine
+3. E-ink magazine
+4. Data dashboard
+5. Retro flat illustration
+6. Hand-drawn technical explainer
+7. Hand-drawn whiteboard
+8. Warm handmade
+9. Scientific defense
+10. Consulting / McKinsey-inspired
+11. Party-and-Government Red
+12. Teaching courseware
+
+Treat these as visual systems, not fixed templates. Adapt structure to the content and avoid repeating the same blueprint on adjacent slides.
+
+## 1. Clean professional
+
+- Palette: cool white `#F7F9FC`, ink `#152238`, muted `#667085`, blue `#2563EB`, cyan `#06B6D4`.
+- Type: geometric sans; 56–72 px titles, 28–34 px body.
+- Composition: spacious grid, one dominant chart or thesis, thin dividers, controlled surfaces.
+- Native techniques: subtle grid gradients, 1 px borders, soft 20–40 px shadows, inline SVG line icons.
+- Avoid: generic SaaS dashboard repetition, blue gradients on every page, excessive pills.
+
+## 2. Creative magazine
+
+- Palette: black/white plus exactly one vivid accent such as `#FF006E`, `#FFED00`, or `#00DDEB`.
+- Type: oversized display sans or editorial serif paired with a quiet sans body.
+- Composition: asymmetric crops, 25–45% headline area, vertical labels, thin rules, edge tension.
+- Native techniques: `clip-path`, rotated metadata, halftone repeating gradients, torn-edge SVG masks, bold color blocks.
+- Avoid: symmetrical corporate cards, multiple competing accents, tiny headline treatment.
+
+## 3. E-ink magazine
+
+- Palette: paper `#F3F0E8`, ink `#1B1B1B`, gray `#77736A`, restrained vermilion `#C44736`.
+- Type: editorial serif headlines with mono or narrow sans metadata.
+- Composition: newspaper columns, evidence captions, pull quotes, diagrams that resemble printed figures.
+- Native techniques: fine paper grain from gradients, 1 px rules, stipple/hatch SVG patterns, monochrome supplied images.
+- Avoid: glossy shadows, neon, large rounded cards, saturated photography.
+
+## 4. Data dashboard
+
+- Palette: near-black `#08111F`, panel `#111D2E`, text `#E7EEF8`, cyan `#22D3EE`, green `#34D399`, amber `#FBBF24`.
+- Type: compact sans plus tabular numerals and mono labels.
+- Composition: one primary metric or analytical view, supporting evidence arranged around it, strong data hierarchy.
+- Native techniques: SVG charts, gridlines, direct labels, conic/radial gradients, low-alpha glow only at key points.
+- Avoid: many equally weighted widgets, decorative metrics, fake live controls, cyberpunk clutter.
+
+## 5. Retro flat illustration
+
+- Palette: cream `#F5F3E8`, slate `#34495E`, coral `#FF6B6B`, mint `#95E1D3`, mustard `#F2C94C`.
+- Type: chunky retro display face with friendly geometric sans.
+- Composition: panoramic native illustration, poster title, outlined callouts and badges.
+- Native techniques: inline SVG flat shapes, consistent 3–4 px outlines, dotted patterns, offset hard shadows.
+- Avoid: photorealism, glossy gradients, inconsistent line weights, dense cartoon scenes.
+
+## 6. Hand-drawn technical explainer
+
+- Palette: near-white `#FCFBF7`, graphite `#2F3437`, pastel blue `#BFD7F1`, sage `#CFE2D1`, peach `#F4C7B8`.
+- Type: restrained handwritten-style system font where available; fall back to a soft sans.
+- Composition: one small central mechanism, short labels, generous whitespace, a few marker highlights.
+- Native techniques: SVG `feTurbulence` and `feDisplacementMap`, slightly irregular strokes, pencil hatching, soft highlight polygons.
+- Avoid: yellow kraft backgrounds, dense whiteboard clutter, cute characters unrelated to the concept.
+
+## 7. Hand-drawn whiteboard
+
+- Palette: white `#FFFEFA`, marker black `#202124`, blue `#4285F4`, red `#EA4335`, green `#34A853`.
+- Type: casual but readable handwritten treatment.
+- Composition: left-to-right explanatory path, circled keywords, arrows, compact diagram clusters.
+- Native techniques: inline SVG marker strokes, double-line circles, uneven underlines, sparse sticky-note rectangles.
+- Avoid: filling every gap, too many marker colors, low-contrast handwriting, classroom clip art.
+
+## 8. Warm handmade
+
+- Palette: warm paper `#F7EFE3`, cocoa `#4A3728`, terracotta `#C96C4B`, olive `#7A8B58`, ochre `#D2A44A`.
+- Type: humanist serif or rounded sans with small handwritten annotations.
+- Composition: tactile layering, irregular frames, calm storytelling, one crafted focal object.
+- Native techniques: paper layers with hard/soft shadows, stitched SVG lines, tape pseudo-elements, fiber-like gradients.
+- Avoid: scrapbook overload, fake vintage stains, low contrast, too many decorative cutouts.
+
+## 9. Scientific defense
+
+- Palette: white `#FFFFFF`, academic blue `#145DA0`, deep blue `#0B2D4D`, red emphasis `#C62828`, gray `#E8EDF2`.
+- Type: strong Chinese sans titles and compact readable body text.
+- Composition: conclusion-led title, technical route, mechanism diagram, evidence panel, or measurable-results table.
+- Native techniques: blue structural labels, red conclusion phrases, SVG mechanisms, aligned scientific figures, precise tables.
+- Avoid: marketing hero pages, decorative stock imagery, empty minimalism, unstructured high density.
+
+## 10. Consulting / McKinsey-inspired
+
+- Palette: white `#FFFFFF`, pale cool gray `#F6F8FA`, ink blue-gray `#243447`, slate `#475569`, line `#D8DEE8`.
+- Type: restrained modern sans; optional engineered outline title made with HTML/SVG strokes.
+- Composition: conclusion-first headline, one analytical mechanism, 3–6 ordered modules, precision annotations.
+- Native techniques: hairline grids, nodes, coordinates, paths, matrices, restrained steel-blue accent, large negative space.
+- Avoid: claiming an official consulting template, generic icon rows, orange as a default accent, repeated card grids.
+
+## 11. Party-and-Government Red
+
+- Palette: Chinese red `#C41E3A`, deep red `#9E1530`, warm ivory `#FFF9F2`, matte gold `#D6A84B`, ink `#262626`.
+- Type: large dignified Chinese sans with disciplined alignment.
+- Composition: formal and balanced, with page-role-driven backgrounds and title placement; use red-led identity without forcing one ceremonial motif.
+- Native techniques: restrained red fields, warm ivory space, fine matte-gold rules, abstract SVG ribbons only when semantically useful.
+- Avoid: invented official marks, glossy gold, festival styling, repeated landmarks, default red navigation bars.
+
+## 12. Teaching courseware
+
+- Palette: choose one calm subject-appropriate primary, light canvas, dark readable text, and one emphasis color.
+- Type: large teaching title, 30–36 px explanatory text, clear labels and definitions.
+- Composition: one learning objective or concept per page; explanation, worked example, process, comparison, or recap selected by pedagogy.
+- Native techniques: SVG annotations, progressive emphasis classes, definition bands, worked-example alignment, accessible charts.
+- Avoid: childish decoration by default, repetitive three-card grids, too much text, unexplained diagrams.
+

--- a/skills/codex-html-slides/references/visual-system.md
+++ b/skills/codex-html-slides/references/visual-system.md
@@ -1,0 +1,161 @@
+# HTML slide visual system
+
+## Contents
+
+1. Coordinate system
+2. Reference-style reconstruction
+3. Typography
+4. Composition and rhythm
+5. Native visual techniques
+6. Diagrams and data
+7. Asset handling
+8. Common failure modes
+
+## 1. Coordinate system
+
+Author each slide on a fixed 1600×900 canvas. The runtime scales the entire stage uniformly, so positions, type, and line weights remain stable across screens.
+
+Use an 80–112 px outer safe area. Establish a deck grid before styling:
+
+```css
+:root {
+  --canvas-w: 1600;
+  --canvas-h: 900;
+  --safe-x: 96px;
+  --safe-y: 72px;
+  --grid-gap: 24px;
+}
+
+.slide-content {
+  position: absolute;
+  inset: var(--safe-y) var(--safe-x);
+}
+```
+
+Decorative geometry may bleed outside the safe area. Keep titles, body text, captions, axes, and required assets inside it.
+
+## 2. Reference-style reconstruction
+
+When a user supplies a style reference, extract a reusable system rather than copying isolated decoration.
+
+Record these observations:
+
+1. Geometry: dominant axes, margins, column ratios, crop behavior, overlap, and focal point.
+2. Palette: background, surface, text, muted text, structural line, and one or two accents.
+3. Typography: font category, title/body ratio, weight, tracking, line height, casing, and alignment.
+4. Shape language: square or rounded, border weight, corner treatment, arrowheads, connectors, and icon style.
+5. Depth: flat, outlined, paper-like, translucent, elevated, embossed, or layered.
+6. Texture: grain, hatch, dot screen, grid, paper fiber, glow, or none.
+7. Density: amount of text, module count, whitespace, and typical diagram complexity.
+8. Rhythm: which elements repeat across the deck and which change by slide role.
+
+Convert the observations to named CSS variables. Use a small token set:
+
+```css
+[data-theme="custom"] {
+  --bg: #f5f2eb;
+  --surface: #fffdf8;
+  --ink: #20252b;
+  --muted: #69717a;
+  --accent: #e0523f;
+  --line: #20252b;
+  --radius: 6px;
+  --shadow: 8px 8px 0 rgb(32 37 43 / 12%);
+}
+```
+
+Match hierarchy, spacing, proportions, and visual grammar before adding small decorative details. These structural attributes contribute more to perceived fidelity than copied ornaments.
+
+## 3. Typography
+
+Use real text instead of outlined or raster text. Prefer system stacks for offline decks:
+
+```css
+--font-sans: Inter, ui-sans-serif, "PingFang SC", "Microsoft YaHei", sans-serif;
+--font-serif: Georgia, "Songti SC", "STSong", serif;
+--font-mono: "SFMono-Regular", Consolas, monospace;
+```
+
+If the user provides a licensed font file, embed it with a data-URI `@font-face`. Do not fetch Google Fonts or another CDN in a self-contained deck.
+
+Recommended 1600×900 ranges:
+
+- Cover title: 96–176 px.
+- Content title: 48–76 px.
+- Key metric: 88–160 px.
+- Body: 26–36 px.
+- Caption or metadata: 18–24 px.
+
+Use deliberate line breaks and balanced line lengths. Avoid more than 8–10 lines in one text block. Split the slide when content only fits below 24 px.
+
+## 4. Composition and rhythm
+
+Give each slide one dominant visual mechanism. Candidate mechanisms include:
+
+- hero typography plus a geometric or SVG counterweight;
+- one large diagram with edge annotations;
+- a 60/40 evidence-and-conclusion split;
+- a comparison axis, matrix, timeline, funnel, system map, or layered architecture;
+- one large number with a cause/effect trail;
+- an editorial collage made from native shapes and supplied content assets.
+
+Vary composition by semantic role. Do not repeat the same three-card grid on adjacent pages. Maintain identity through palette, type, line style, and spacing rather than a rigid master layout.
+
+## 5. Native visual techniques
+
+Use CSS gradients to create atmosphere:
+
+```css
+.slide {
+  background:
+    radial-gradient(circle at 78% 24%, rgb(99 102 241 / 18%), transparent 26%),
+    linear-gradient(145deg, #fafcff, #eef2ff 58%, #f8fafc);
+}
+```
+
+Use repeating gradients for paper ruling, grids, halftone, and hatching. Use `clip-path` for wedges and crops. Use pseudo-elements for crop marks, tape, underlines, ribbons, and oversized numerals.
+
+Use inline SVG for:
+
+- curved connectors and arrow markers;
+- hand-drawn paths with `filter` turbulence/displacement;
+- technical grids and architectural linework;
+- charts, maps, node networks, and exploded diagrams;
+- masks, clipping paths, patterns, and duotone filters.
+
+Keep SVG `viewBox` coordinates stable. Mark purely decorative SVG as `aria-hidden="true"`. Give meaningful SVG a `<title>` and a descriptive `aria-label`.
+
+Use `mix-blend-mode`, `backdrop-filter`, and blur sparingly. Always provide sufficient contrast when effects are unsupported.
+
+## 6. Diagrams and data
+
+Start with the relationship, not the container. Ask what the viewer must understand: sequence, comparison, hierarchy, feedback, ownership, magnitude, or dependency.
+
+Build charts and diagrams with direct labels. Use one accent to identify the conclusion. Avoid legends that force repeated eye travel. Include units, time periods, baselines, and sources when present in the material.
+
+For dense tables, emphasize rows or columns structurally rather than adding more colors. Use tabular numerals and align decimal places.
+
+## 7. Asset handling
+
+Supplied images may be used as content evidence. Preserve labels and essential regions. Crop only when the user permits it.
+
+For a self-contained deck:
+
+- embed raster assets as base64 data URIs;
+- inline SVG assets after sanitizing unsafe scripts and external links;
+- include meaningful `alt` text;
+- keep image dimensions explicit to prevent layout shifts.
+
+Do not embed a full reference slide or generated screenshot as a background. The page must remain a composition of editable native elements.
+
+## 8. Common failure modes
+
+- Web-dashboard look: too many uniform cards, pills, and icon tiles.
+- Template repetition: identical title bars and three-column modules on every slide.
+- Decoration without concept: arbitrary gradients, blobs, and lines that do not reinforce meaning.
+- Weak hierarchy: title, body, data, and annotations have similar visual weight.
+- Tiny-text rescue: content is forced below presentation-readable sizes.
+- Fake richness: many shadows and effects replace composition and information design.
+- Raster shortcut: a finished slide image is placed behind token HTML.
+- Reference mismatch: colors are copied, but geometry, density, typography, and shape language are not.
+

--- a/skills/codex-html-slides/scripts/create_deck.py
+++ b/skills/codex-html-slides/scripts/create_deck.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Create a self-contained HTML slide deck from the bundled template."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from pathlib import Path
+
+
+THEMES = (
+    "clean-professional",
+    "creative-magazine",
+    "e-ink-magazine",
+    "data-dashboard",
+    "retro-flat",
+    "handdrawn-technical",
+    "handdrawn-whiteboard",
+    "warm-handmade",
+    "scientific-defense",
+    "consulting",
+    "party-red",
+    "teaching-courseware",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", help="Destination .html file")
+    parser.add_argument("--title", default="Untitled presentation", help="Deck title")
+    parser.add_argument("--lang", default="zh-CN", help="HTML language tag, such as zh-CN or en")
+    parser.add_argument("--theme", choices=THEMES, default="clean-professional")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing output file")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    if output.suffix.lower() not in {".html", ".htm"}:
+        raise SystemExit(f"Output must use .html or .htm: {output}")
+    if output.exists() and not args.force:
+        raise SystemExit(f"Output already exists: {output} (pass --force to overwrite)")
+    if not re.fullmatch(r"[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*", args.lang):
+        raise SystemExit(f"Invalid language tag: {args.lang}")
+
+    template = Path(__file__).resolve().parents[1] / "assets" / "deck-template.html"
+    content = template.read_text(encoding="utf-8")
+    replacements = {
+        "{{DECK_TITLE}}": html.escape(args.title, quote=True),
+        "{{DECK_LANG}}": args.lang,
+        "{{DECK_THEME}}": args.theme,
+    }
+    for marker, value in replacements.items():
+        content = content.replace(marker, value)
+
+    unresolved = sorted(set(re.findall(r"\{\{[A-Z0-9_]+\}\}", content)))
+    if unresolved:
+        raise SystemExit(f"Template contains unresolved markers: {', '.join(unresolved)}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content, encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "theme": args.theme,
+                "title": args.title,
+                "self_contained": True,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/skills/codex-html-slides/scripts/validate_deck.py
+++ b/skills/codex-html-slides/scripts/validate_deck.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Validate structure, accessibility, and self-containment of an HTML slide deck."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+
+VOID_TAGS = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"}
+RASTER_EXTENSIONS = ("png", "jpe?g", "webp", "gif", "bmp", "tiff?")
+DATA_OR_ANCHOR = re.compile(r"^(?:data:|#|mailto:|tel:)", re.IGNORECASE)
+
+
+class DeckParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.doctype = False
+        self.html_lang = ""
+        self.viewport = False
+        self.ids: list[str] = []
+        self.slides: list[dict[str, Any]] = []
+        self.current_slide: dict[str, Any] | None = None
+        self.slide_depth: int | None = None
+        self.depth = 0
+        self.in_style = False
+        self.in_script = False
+        self.styles: list[str] = []
+        self.scripts: list[str] = []
+        self.external_assets: list[str] = []
+        self.images: list[dict[str, Any]] = []
+        self.script_sources: list[str] = []
+        self.stylesheet_links: list[str] = []
+        self.frames: list[str] = []
+        self.object_tags = 0
+
+    @staticmethod
+    def _attrs(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
+        return {key: value or "" for key, value in attrs}
+
+    def handle_decl(self, decl: str) -> None:
+        if decl.lower().strip() == "doctype html":
+            self.doctype = True
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = self._attrs(attrs)
+        classes = set(values.get("class", "").split())
+        if tag not in VOID_TAGS:
+            self.depth += 1
+
+        if tag == "html":
+            self.html_lang = values.get("lang", "").strip()
+        elif tag == "meta" and values.get("name", "").lower() == "viewport":
+            self.viewport = bool(values.get("content", "").strip())
+        elif tag == "style":
+            self.in_style = True
+        elif tag == "script":
+            self.in_script = True
+            if values.get("src"):
+                self.script_sources.append(values["src"])
+        elif tag == "link" and "stylesheet" in values.get("rel", "").lower().split():
+            self.stylesheet_links.append(values.get("href", ""))
+        elif tag in {"iframe", "frame"}:
+            self.frames.append(values.get("src", ""))
+        elif tag in {"object", "embed"}:
+            self.object_tags += 1
+
+        element_id = values.get("id", "").strip()
+        if element_id:
+            self.ids.append(element_id)
+
+        if tag == "section" and "slide" in classes and "data-slide" in values:
+            slide = {
+                "id": element_id,
+                "aria_label": values.get("aria-label", "").strip(),
+                "aria_labelledby": values.get("aria-labelledby", "").strip(),
+                "headings": 0,
+                "text_chars": 0,
+                "notes": 0,
+            }
+            self.slides.append(slide)
+            self.current_slide = slide
+            self.slide_depth = self.depth
+        elif self.current_slide is not None:
+            if tag in {"h1", "h2", "h3"}:
+                self.current_slide["headings"] += 1
+            if tag == "aside" and "speaker-notes" in classes:
+                self.current_slide["notes"] += 1
+
+        if tag == "img":
+            src = values.get("src", "").strip()
+            self.images.append({"src": src, "alt": values.get("alt", ""), "alt_present": "alt" in values})
+            if src and not DATA_OR_ANCHOR.match(src):
+                self.external_assets.append(src)
+        elif tag in {"audio", "video", "source", "track"}:
+            src = values.get("src", "").strip()
+            if src and not DATA_OR_ANCHOR.match(src):
+                self.external_assets.append(src)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "style":
+            self.in_style = False
+        elif tag == "script":
+            self.in_script = False
+
+        if tag == "section" and self.current_slide is not None and self.slide_depth == self.depth:
+            self.current_slide = None
+            self.slide_depth = None
+
+        if tag not in VOID_TAGS:
+            self.depth = max(0, self.depth - 1)
+
+    def handle_data(self, data: str) -> None:
+        if self.in_style:
+            self.styles.append(data)
+        elif self.in_script:
+            self.scripts.append(data)
+        elif self.current_slide is not None:
+            self.current_slide["text_chars"] += len("".join(data.split()))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("deck", help="HTML deck to validate")
+    parser.add_argument("--expect-slides", type=int, help="Require an exact slide count")
+    parser.add_argument("--allow-external", action="store_true", help="Allow non-embedded assets and network dependencies")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as errors")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser.parse_args()
+
+
+def inspect_deck(path: Path, args: argparse.Namespace) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if path.suffix.lower() not in {".html", ".htm"}:
+        errors.append("Deck must use the .html or .htm extension.")
+
+    text = path.read_text(encoding="utf-8")
+    parser = DeckParser()
+    try:
+        parser.feed(text)
+        parser.close()
+    except Exception as exc:  # HTMLParser errors are rare, but report them cleanly.
+        errors.append(f"HTML parsing failed: {exc}")
+
+    css = "\n".join(parser.styles)
+    js = "\n".join(parser.scripts)
+    lowered = text.lower()
+
+    if not parser.doctype:
+        errors.append("Missing <!doctype html> declaration.")
+    if not parser.html_lang:
+        errors.append("The <html> element must declare lang.")
+    if not parser.viewport:
+        errors.append("Missing viewport meta tag.")
+    if not parser.slides:
+        errors.append('No <section class="slide" data-slide> elements found.')
+    if args.expect_slides is not None and len(parser.slides) != args.expect_slides:
+        errors.append(f"Expected {args.expect_slides} slides, found {len(parser.slides)}.")
+
+    duplicate_ids = sorted({item for item in parser.ids if parser.ids.count(item) > 1})
+    if duplicate_ids:
+        errors.append(f"Duplicate element ids: {', '.join(duplicate_ids)}")
+
+    known_ids = set(parser.ids)
+    slide_ids: list[str] = []
+    for number, slide in enumerate(parser.slides, start=1):
+        slide_id = slide["id"]
+        if not slide_id:
+            errors.append(f"Slide {number} is missing an id.")
+        else:
+            slide_ids.append(slide_id)
+        if not slide["aria_label"] and not slide["aria_labelledby"]:
+            errors.append(f"Slide {number} needs aria-label or aria-labelledby.")
+        if slide["aria_labelledby"] and slide["aria_labelledby"] not in known_ids:
+            errors.append(f"Slide {number} references missing label id: {slide['aria_labelledby']}")
+        if slide["headings"] == 0:
+            warnings.append(f"Slide {number} has no h1, h2, or h3 heading.")
+        if slide["text_chars"] < 8:
+            warnings.append(f"Slide {number} has very little readable text.")
+
+    if len(set(slide_ids)) != len(slide_ids):
+        errors.append("Slide ids must be unique.")
+
+    if parser.script_sources:
+        message = f"External script sources: {', '.join(parser.script_sources)}"
+        (warnings if args.allow_external else errors).append(message)
+    if parser.stylesheet_links:
+        message = f"External stylesheet links: {', '.join(parser.stylesheet_links)}"
+        (warnings if args.allow_external else errors).append(message)
+    if parser.frames:
+        message = f"Embedded frames are not self-contained: {', '.join(parser.frames)}"
+        (warnings if args.allow_external else errors).append(message)
+    if parser.object_tags:
+        errors.append("Object/embed elements are not allowed in the default self-contained contract.")
+    if parser.external_assets:
+        message = f"Non-embedded media assets: {', '.join(sorted(set(parser.external_assets)))}"
+        (warnings if args.allow_external else errors).append(message)
+
+    for number, image in enumerate(parser.images, start=1):
+        if not image["alt_present"]:
+            warnings.append(f"Image {number} is missing alt text; use alt=\"\" for decoration.")
+
+    css_external_urls = [
+        value.strip(" \"'")
+        for value in re.findall(r"url\(([^)]+)\)", css, flags=re.IGNORECASE)
+        if not DATA_OR_ANCHOR.match(value.strip(" \"'"))
+    ]
+    if css_external_urls:
+        message = f"CSS references non-embedded URLs: {', '.join(sorted(set(css_external_urls)))}"
+        (warnings if args.allow_external else errors).append(message)
+    if re.search(r"@import\s+", css, flags=re.IGNORECASE):
+        message = "CSS @import is not self-contained."
+        (warnings if args.allow_external else errors).append(message)
+
+    raster_pattern = rf"(?:origin_image|slide[_-]?\d+\.(?:{'|'.join(RASTER_EXTENSIONS)}))"
+    if re.search(raster_pattern, lowered, flags=re.IGNORECASE):
+        errors.append("Detected a full-slide raster or origin_image reference.")
+    if re.search(r"\.(?:png|jpe?g|webp|gif|bmp|tiff?)[\"')\s]", lowered) and not parser.images:
+        warnings.append("Raster filename found outside an <img>; verify it is a required content asset, not a slide background.")
+    if re.search(r"\.to(?:dataurl|blob)\s*\(", lowered) or "html2canvas" in lowered:
+        errors.append("Detected canvas/screenshot export code, which violates the HTML-only contract.")
+
+    compact_css = re.sub(r"\s+", "", css.lower())
+    if "--canvas-width:1600px" not in compact_css or "--canvas-height:900px" not in compact_css:
+        errors.append("Missing fixed 1600×900 canvas variables.")
+    if "@mediaprint" not in compact_css:
+        warnings.append("Missing print stylesheet.")
+    if "prefers-reduced-motion" not in css:
+        warnings.append("Missing reduced-motion support.")
+
+    for token in ("ArrowRight", "ArrowLeft", "PageDown", "PageUp", "Home", "End"):
+        if token not in js:
+            errors.append(f"Navigation runtime is missing {token} handling.")
+    if "requestFullscreen" not in js:
+        warnings.append("Missing fullscreen support.")
+    if "location.hash" not in js:
+        warnings.append("Missing hash-based slide navigation.")
+    if "data-counter" not in lowered:
+        warnings.append("Missing visible slide counter.")
+
+    status = "ok" if not errors and not (args.strict and warnings) else "failed"
+    return {
+        "status": status,
+        "deck": str(path),
+        "slide_count": len(parser.slides),
+        "self_contained": not any((parser.script_sources, parser.stylesheet_links, parser.external_assets, css_external_urls, parser.frames)),
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.deck).expanduser().resolve()
+    if not path.is_file():
+        raise SystemExit(f"Deck not found: {path}")
+    result = inspect_deck(path, args)
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(f"Deck: {result['deck']}")
+        print(f"Slides: {result['slide_count']}")
+        print(f"Self-contained: {str(result['self_contained']).lower()}")
+        for error in result["errors"]:
+            print(f"ERROR: {error}")
+        for warning in result["warnings"]:
+            print(f"WARNING: {warning}")
+        print(f"Result: {result['status'].upper()}")
+    return 0 if result["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a standalone `codex-html-slides` skill that produces self-contained HTML presentations without full-slide raster outputs
- include a reusable 1600×900 presentation runtime, 12 native HTML style recipes, and guidance for translating reference-image aesthetics into DOM/CSS/inline SVG
- add deterministic deck creation and validation scripts
- package the new skill in release ZIPs and document installation in both READMEs

## User-visible changes

Users can now create offline-ready HTML slide decks whose page elements remain editable in source. The workflow intentionally avoids image-generation backends, slide screenshots, PPTX, and PDF output while preserving image-quality composition through native browser techniques.

## Changelog

- [x] Updated `CHANGELOG.md`
- [ ] Not needed: internal-only change

The changelog entry includes the required `(#88)` PR reference.

## Verification

- `quick_validate.py skills/codex-html-slides`
- Python bytecode compilation for both bundled scripts
- strict create/validate round-trip for all 12 themes
- negative validation test for external script rejection
- in-app browser QA at 1600×900, 1366×768, and 390×844, including overflow, notes controls, and console errors
- Ruby YAML parse and `bash -n` check for the changed release workflow block
- release ZIP smoke test confirming the new skill files are packaged
